### PR TITLE
FColor RGBA -> BGRA

### DIFF
--- a/CUE4Parse/UE4/Objects/Core/Math/FColor.cs
+++ b/CUE4Parse/UE4/Objects/Core/Math/FColor.cs
@@ -14,9 +14,9 @@ namespace CUE4Parse.UE4.Objects.Core.Math
     [StructLayout(LayoutKind.Sequential)]
     public readonly struct FColor : IUStruct
     {
-        public readonly byte R;
-        public readonly byte G;
         public readonly byte B;
+        public readonly byte G;
+        public readonly byte R;
         public readonly byte A;
 
         public string Hex => A is 1 or 0 ? UnsafePrint.BytesToHex(R, G, B) : UnsafePrint.BytesToHex(A, R, G, B);


### PR DESCRIPTION
[Since UE3, FColor has different memory layout - BGRA. -- /UEViewer/.../UnCore.h#L2462-L2465](https://github.com/gildor2/UEViewer/blob/master/Unreal/UnCore.h#L2462-L2465)
&
[/UnrealEngine/.../Color.h#L413-L421](https://github.com/EpicGames/UnrealEngine/blob/release/Engine/Source/Runtime/Core/Public/Math/Color.h#L413-L421)

Vertex colors:
![image](https://user-images.githubusercontent.com/57007485/140577565-151752e1-3d1c-4253-9e62-bcef92578fd9.png)
