### PR TITLE
Fix FUECompressedAnimData.CompressedByteStream being read too early in 4.23-4.24

### DIFF
--- a/CUE4Parse/UE4/Assets/Exports/Animation/AnimCompressionTypes.cs
+++ b/CUE4Parse/UE4/Assets/Exports/Animation/AnimCompressionTypes.cs
@@ -125,10 +125,19 @@ namespace CUE4Parse.UE4.Assets.Exports.Animation
                 ((ICompressedAnimData) this).BaseSerializeCompressedData(Ar);
             }
 
-            CompressedByteStream = new byte[Ar.Read<int>()];
+            if (baseFirst)
+            {
+                CompressedByteStream = new byte[Ar.Read<int>()];
+            }
+
             CompressedTrackOffsets = new int[Ar.Read<int>()];
             CompressedScaleOffsets.OffsetData = new int[Ar.Read<int>()];
             CompressedScaleOffsets.StripSize = Ar.Read<int>();
+
+            if (!baseFirst)
+            {
+                CompressedByteStream = new byte[Ar.Read<int>()];
+            }
         }
 
         public void Bind(byte[] bulkData) => InitViewsFromBuffer(bulkData);


### PR DESCRIPTION
CompressedByteStream is read after CompressedScaleOffsets in 4.23-4.24, but before CompressedTrackOffsets in 4.25 and later.

SerializeCompressedData2: https://github.com/gildor2/UEViewer/blob/e879659ab154930630279ba8c10ed0fd022f27e6/Unreal/UnrealMesh/UnAnim4.cpp#L1362-L1365

SerializeCompressedData3: https://github.com/gildor2/UEViewer/blob/e879659ab154930630279ba8c10ed0fd022f27e6/Unreal/UnrealMesh/UnAnim4.cpp#L1493-L1496