### PR TITLE
Increase the default FString limits

### DIFF
--- a/CUE4Parse/UE4/Readers/FArchive.cs
+++ b/CUE4Parse/UE4/Readers/FArchive.cs
@@ -281,7 +281,7 @@ namespace CUE4Parse.UE4.Readers
             if (length == int.MinValue)
                 throw new ArgumentOutOfRangeException(nameof(length), "Archive is corrupted");
 
-            if (length is < -131072 or > 131072)
+            if (length is < -512000 or > 512000)
                 throw new ParserException($"Invalid FString length '{length}'");
 
             if (length == 0)


### PR DESCRIPTION
This enables ability to parse large FiBData blocks. Since these blocks can be essentially an arbitrary size may be it would be better to introduce default parameter for the `ReadFString` function that would be used to ignore in-place limits. Since it is a default one, it will keep compatibility in tact and only requires internal changes to library's inheriting members.