### PR TITLE
Fixing FInstancedStaticMeshInstanceData

### DIFF
--- a/CUE4Parse/UE4/Assets/Exports/Component/StaticMesh/FInstancedStaticMeshInstanceData.cs
+++ b/CUE4Parse/UE4/Assets/Exports/Component/StaticMesh/FInstancedStaticMeshInstanceData.cs
@@ -7,34 +7,13 @@ namespace CUE4Parse.UE4.Assets.Exports.Component.StaticMesh
     {
         private readonly FMatrix Transform; // don't expose the raw matrix for now
 
-        // TODO: replicate the way UE handles this data, until then this should work better than a matrix I suppose
-        public readonly FVector OffsetLocation;
-        public readonly FRotator RelativeRotation;
-        public readonly FVector RelativeScale3D;
+        public FTransform TransformData;
 
         public FInstancedStaticMeshInstanceData(FArchive Ar)
         {
             Transform = new FMatrix(Ar);
 
-            OffsetLocation = Transform.GetOrigin();
-            RelativeRotation = Transform.Rotator();
-            RelativeScale3D = Transform.GetScaleVector();
+            TransformData.SetFromMatrix(Transform);
         }
-
-        // TODO: 
-        // public FVector GetLocation()
-        // {
-        //     ...
-        // }
-
-        // public FRotator GetRotation()
-        // {
-        //     ...
-        // }
-
-        // public FVector GetScale3D()
-        // {
-        //     ...
-        // }
     }
 }

--- a/CUE4Parse/UE4/Objects/Core/Math/FQuat.cs
+++ b/CUE4Parse/UE4/Objects/Core/Math/FQuat.cs
@@ -61,8 +61,8 @@ namespace CUE4Parse.UE4.Objects.Core.Math
 
             if (tr > 0.0f)
             {
-                var invS = (tr + 1).InvSqrt();
-                W = 0.5f * (1f / invS);
+                var invS = 1.0f / Sqrt(tr + 1.0f);
+                W = 0.5f * (1.0f / invS);
                 s = 0.5f * invS;
 
                 X = (m.M12 - m.M21) * s;
@@ -77,24 +77,24 @@ namespace CUE4Parse.UE4.Objects.Core.Math
                 if (m.M11 > m.M00)
                     i = 1;
 
-                if (m.M22 > (i == 1 ? m.M11 : m.M00))
+                if (m.M22 > m[4*i+i])
                     i = 2;
 
                 var j = matrixNxt[i];
                 var k = matrixNxt[j];
 
-                s = (i switch { 0 => m.M00, 1 => m.M11, _ => m.M22}) - (j switch { 0 => m.M00, 1 => m.M11, _ => m.M22}) + 1.0f;
+                s = m[4*i+i] - m[4*j+j] - m[4*k+k] + 1.0f;
 
-                var invS = s.InvSqrt();
+                var invS = 1.0f / Sqrt(s);
 
                 Span<float> qt = stackalloc float[4];
-                qt[i] = 0.5f * (1f / invS);
+                qt[i] = 0.5f * (1.0f / invS);
 
                 s = 0.5f * invS;
 
-                qt[3] = (j switch {0 => k switch {0 => m.M00, 1 => m.M01, _ => m.M02}, 1 => k switch {0 => m.M10, 1 => m.M11, _ => m.M12}, _ => k switch {0 => m.M10, 1 => m.M11, _ => m.M12}}) - (k switch {0 => j switch {0 => m.M00, 1 => m.M01, _ => m.M02}, 1 => j switch {0 => m.M10, 1 => m.M11, _ => m.M12}, _ => j switch {0 => m.M10, 1 => m.M11, _ => m.M12}}) * s;
-                qt[j] = (i switch {0 => j switch {0 => m.M00, 1 => m.M01, _ => m.M02}, 1 => j switch {0 => m.M10, 1 => m.M11, _ => m.M12}, _ => j switch {0 => m.M10, 1 => m.M11, _ => m.M12}}) - (j switch {0 => i switch {0 => m.M00, 1 => m.M01, _ => m.M02}, 1 => i switch {0 => m.M10, 1 => m.M11, _ => m.M12}, _ => i switch {0 => m.M10, 1 => m.M11, _ => m.M12}}) * s;
-                qt[k] = (i switch {0 => k switch {0 => m.M00, 1 => m.M01, _ => m.M02}, 1 => k switch {0 => m.M10, 1 => m.M11, _ => m.M12}, _ => k switch {0 => m.M10, 1 => m.M11, _ => m.M12}}) - (k switch {0 => i switch {0 => m.M00, 1 => m.M01, _ => m.M02}, 1 => i switch {0 => m.M10, 1 => m.M11, _ => m.M12}, _ => i switch {0 => m.M10, 1 => m.M11, _ => m.M12}}) * s;
+                qt[3] = (m[4*j+k] - m[4*k+j]) * s;
+                qt[j] = (m[4*i+j] + m[4*j+i]) * s;
+                qt[k] = (m[4*i+k] + m[4*k+i]) * s;
 
                 X = qt[0];
                 Y = qt[1];

--- a/CUE4Parse/UE4/Objects/Core/Math/FTransform.cs
+++ b/CUE4Parse/UE4/Objects/Core/Math/FTransform.cs
@@ -67,6 +67,29 @@ namespace CUE4Parse.UE4.Objects.Core.Math
             Scale3D = data.GetOrDefault<FVector>(nameof(Scale3D));
         }
 
+        public void SetFromMatrix(FMatrix InMatrix)
+        {
+            FMatrix M = new(InMatrix);
+
+            // Get the 3D scale from the matrix
+            Scale3D = M.ExtractScaling();
+
+            // If there is negative scaling going on, we handle that here
+            if (InMatrix.Determinant() < 0.0f)
+            {
+                // Assume it is along X and modify transform accordingly. 
+                // It doesn't actually matter which axis we choose, the 'appearance' will be the same
+                Scale3D.X *= -1.0f;
+                M.SetAxis(0, -M.GetScaledAxis(EAxis.X));
+            }
+
+            Rotation = M.ToQuat();
+            Translation = InMatrix.GetOrigin();
+
+            // Normalize rotation
+            Rotation.Normalize();
+        }
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public FRotator Rotator() => Rotation.Rotator();
 

--- a/CUE4Parse/UE4/Objects/Core/Math/FTransform.cs
+++ b/CUE4Parse/UE4/Objects/Core/Math/FTransform.cs
@@ -67,24 +67,24 @@ namespace CUE4Parse.UE4.Objects.Core.Math
             Scale3D = data.GetOrDefault<FVector>(nameof(Scale3D));
         }
 
-        public void SetFromMatrix(FMatrix InMatrix)
+        public void SetFromMatrix(FMatrix inMatrix)
         {
-            FMatrix M = new(InMatrix);
+            FMatrix m = new(inMatrix);
 
             // Get the 3D scale from the matrix
-            Scale3D = M.ExtractScaling();
+            Scale3D = m.ExtractScaling();
 
             // If there is negative scaling going on, we handle that here
-            if (InMatrix.Determinant() < 0.0f)
+            if (inMatrix.Determinant() < 0.0f)
             {
                 // Assume it is along X and modify transform accordingly. 
                 // It doesn't actually matter which axis we choose, the 'appearance' will be the same
                 Scale3D.X *= -1.0f;
-                M.SetAxis(0, -M.GetScaledAxis(EAxis.X));
+                m.SetAxis(0, -m.GetScaledAxis(EAxis.X));
             }
 
-            Rotation = M.ToQuat();
-            Translation = InMatrix.GetOrigin();
+            Rotation = m.ToQuat();
+            Translation = inMatrix.GetOrigin();
 
             // Normalize rotation
             Rotation.Normalize();

--- a/CUE4Parse/UE4/Objects/Core/Math/Matrix.cs
+++ b/CUE4Parse/UE4/Objects/Core/Math/Matrix.cs
@@ -30,12 +30,12 @@ namespace CUE4Parse.UE4.Objects.Core.Math
 
         public FMatrix() {}
 
-        public FMatrix(FMatrix M)
+        public FMatrix(FMatrix m)
         {
-            M00 = M.M00; M01 = M.M01; M02 = M.M02; M03 = M.M03;
-            M10 = M.M10; M11 = M.M11; M12 = M.M12; M13 = M.M13;
-            M20 = M.M20; M21 = M.M21; M22 = M.M22; M23 = M.M23;
-            M30 = M.M30; M31 = M.M31; M32 = M.M32; M33 = M.M33;
+            M00 = m.M00; M01 = m.M01; M02 = m.M02; M03 = m.M03;
+            M10 = m.M10; M11 = m.M11; M12 = m.M12; M13 = m.M13;
+            M20 = m.M20; M21 = m.M21; M22 = m.M22; M23 = m.M23;
+            M30 = m.M30; M31 = m.M31; M32 = m.M32; M33 = m.M33;
         }
 
         public FMatrix(
@@ -326,51 +326,51 @@ namespace CUE4Parse.UE4.Objects.Core.Math
             var squareSum1 = M10*M10 + M11*M11 + M12*M12;
             var squareSum2 = M20*M20 + M21*M21 + M22*M22;
 
-            FVector Scale3D = new();
+            FVector scale3D = new();
 
             if (squareSum0 > tolerance)
             {
-                float Scale0 = MathF.Sqrt(squareSum0);
-                Scale3D.X = Scale0;
-                float InvScale0 = 1.0f / Scale0;
-                M00 *= InvScale0;
-                M01 *= InvScale0;
-                M02 *= InvScale0;
+                float scale0 = MathF.Sqrt(squareSum0);
+                scale3D.X = scale0;
+                float invScale0 = 1.0f / scale0;
+                M00 *= invScale0;
+                M01 *= invScale0;
+                M02 *= invScale0;
             }
             else
             {
-                Scale3D.X = 0.0f;
+                scale3D.X = 0.0f;
             }
 
             if (squareSum1 > tolerance)
             {
-                float Scale1 = MathF.Sqrt(squareSum1);
-                Scale3D.Y = Scale1;
-                float InvScale1 = 1.0f / Scale1;
-                M10 *= InvScale1;
-                M11 *= InvScale1;
-                M12 *= InvScale1;
+                float scale1 = MathF.Sqrt(squareSum1);
+                scale3D.Y = scale1;
+                float invScale1 = 1.0f / scale1;
+                M10 *= invScale1;
+                M11 *= invScale1;
+                M12 *= invScale1;
             }
             else
             {
-                Scale3D.Y = 0.0f;
+                scale3D.Y = 0.0f;
             }
 
             if (squareSum2 > tolerance)
             {
-                float Scale2 = MathF.Sqrt(squareSum2);
-                Scale3D.Z = Scale2;
-                float InvScale2 = 1.0f / Scale2;
-                M20 *= InvScale2;
-                M21 *= InvScale2;
-                M22 *= InvScale2;
+                float scale2 = MathF.Sqrt(squareSum2);
+                scale3D.Z = scale2;
+                float invScale2 = 1.0f / scale2;
+                M20 *= invScale2;
+                M21 *= invScale2;
+                M22 *= invScale2;
             }
             else
             {
-                Scale3D.Z = 0.0f;
+                scale3D.Z = 0.0f;
             }
 
-            return Scale3D;
+            return scale3D;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/CUE4Parse/UE4/Objects/Core/Math/Matrix.cs
+++ b/CUE4Parse/UE4/Objects/Core/Math/Matrix.cs
@@ -30,6 +30,14 @@ namespace CUE4Parse.UE4.Objects.Core.Math
 
         public FMatrix() {}
 
+        public FMatrix(FMatrix M)
+        {
+            M00 = M.M00; M01 = M.M01; M02 = M.M02; M03 = M.M03;
+            M10 = M.M10; M11 = M.M11; M12 = M.M12; M13 = M.M13;
+            M20 = M.M20; M21 = M.M21; M22 = M.M22; M23 = M.M23;
+            M30 = M.M30; M31 = M.M31; M32 = M.M32; M33 = M.M33;
+        }
+
         public FMatrix(
             float m00, float m01, float m02, float m03,
             float m10, float m11, float m12, float m13,
@@ -81,6 +89,53 @@ namespace CUE4Parse.UE4.Objects.Core.Math
             a.M30 * b.M02 + a.M31 * b.M12 + a.M32 * b.M22 + a.M33 * b.M32,
             a.M30 * b.M03 + a.M31 * b.M13 + a.M32 * b.M23 + a.M33 * b.M33
         );
+
+        public float this[int i]
+        {
+            get => i switch
+            {
+                0 => M00,
+                1 => M01,
+                2 => M02,
+                3 => M03,
+                4 => M10,
+                5 => M11,
+                6 => M12,
+                7 => M13,
+                8 => M20,
+                9 => M21,
+                10 => M22,
+                11 => M23,
+                12 => M30,
+                13 => M31,
+                14 => M32,
+                15 => M33,
+                _ => throw new IndexOutOfRangeException(),
+            };
+            set
+            {
+                switch (i)
+                {
+                    case 0: M00 = value; break;
+                    case 1: M01 = value; break;
+                    case 2: M02 = value; break;
+                    case 3: M03 = value; break;
+                    case 4: M10 = value; break;
+                    case 5: M11 = value; break;
+                    case 6: M12 = value; break;
+                    case 7: M13 = value; break;
+                    case 8: M20 = value; break;
+                    case 9: M21 = value; break;
+                    case 10: M22 = value; break;
+                    case 11: M23 = value; break;
+                    case 12: M30 = value; break;
+                    case 13: M31 = value; break;
+                    case 14: M32 = value; break;
+                    case 15: M33 = value; break;
+                    default: throw new IndexOutOfRangeException();
+                }
+            }
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public FVector4 TransformFVector4(FVector4 p) => new(
@@ -261,6 +316,61 @@ namespace CUE4Parse.UE4.Objects.Core.Math
             M20 *= scale2;
             M21 *= scale2;
             M22 *= scale2;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public FVector ExtractScaling(float tolerance = UnrealMath.SmallNumber)
+        {
+            // For each row, find magnitude, and if its non-zero re-scale so its unit length.
+            var squareSum0 = M00*M00 + M01*M01 + M02*M02;
+            var squareSum1 = M10*M10 + M11*M11 + M12*M12;
+            var squareSum2 = M20*M20 + M21*M21 + M22*M22;
+
+            FVector Scale3D = new();
+
+            if (squareSum0 > tolerance)
+            {
+                float Scale0 = MathF.Sqrt(squareSum0);
+                Scale3D.X = Scale0;
+                float InvScale0 = 1.0f / Scale0;
+                M00 *= InvScale0;
+                M01 *= InvScale0;
+                M02 *= InvScale0;
+            }
+            else
+            {
+                Scale3D.X = 0.0f;
+            }
+
+            if (squareSum1 > tolerance)
+            {
+                float Scale1 = MathF.Sqrt(squareSum1);
+                Scale3D.Y = Scale1;
+                float InvScale1 = 1.0f / Scale1;
+                M10 *= InvScale1;
+                M11 *= InvScale1;
+                M12 *= InvScale1;
+            }
+            else
+            {
+                Scale3D.Y = 0.0f;
+            }
+
+            if (squareSum2 > tolerance)
+            {
+                float Scale2 = MathF.Sqrt(squareSum2);
+                Scale3D.Z = Scale2;
+                float InvScale2 = 1.0f / Scale2;
+                M20 *= InvScale2;
+                M21 *= InvScale2;
+                M22 *= InvScale2;
+            }
+            else
+            {
+                Scale3D.Z = 0.0f;
+            }
+
+            return Scale3D;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
This PR fixes the incorrect rotation values in FInstancedStaticMeshInstanceData by removing scaling from the transformation matrix before getting the rotation data.

`ExtractScaling()` (for FMatrix) and `SetFromMatrix()` (for FTransform) methods were added and FMatrix => FQuat ( `ToQuat()` ) was fixed.
An indexer for FMatrix was also added.
Fast inverse square root was replaced as it's not sufficient here.