### PR TITLE
ADD_SOFTOBJECTPATH_LIST in FPackageFileSummary

### DIFF
--- a/CUE4Parse/UE4/Objects/UObject/FPackageFileSummary.cs
+++ b/CUE4Parse/UE4/Objects/UObject/FPackageFileSummary.cs
@@ -44,6 +44,8 @@ namespace CUE4Parse.UE4.Objects.UObject
         public readonly string FolderName;
         public int NameCount;
         public readonly int NameOffset;
+        public readonly int SoftObjectPathsCount;
+        public readonly int SoftObjectPathsOffset;
         public readonly string? LocalizationId;
         public readonly int GatherableTextDataCount;
         public readonly int GatherableTextDataOffset;
@@ -198,6 +200,12 @@ namespace CUE4Parse.UE4.Objects.UObject
             afterPackageFlags:
             NameCount = Ar.Read<int>();
             NameOffset = Ar.Read<int>();
+
+            if (FileVersionUE.FileVersionUE5 >= EUnrealEngineObjectUE5Version.ADD_SOFTOBJECTPATH_LIST)
+            {
+                SoftObjectPathsCount = Ar.Read<int>();
+                SoftObjectPathsOffset = Ar.Read<int>();
+            }
 
             if (!PackageFlags.HasFlag(EPackageFlags.PKG_FilterEditorOnly))
             {

--- a/CUE4Parse/UE4/Versions/EGame.cs
+++ b/CUE4Parse/UE4/Versions/EGame.cs
@@ -89,7 +89,7 @@ namespace CUE4Parse.UE4.Versions
                 return game switch
                 {
                     EGame.GAME_UE5_0 => new(522, 1004),
-                    EGame.GAME_UE5_1 => new(522, 1006),
+                    EGame.GAME_UE5_1 => new(522, 1008),
                     _ => new((int) EUnrealEngineObjectUE4Version.AUTOMATIC_VERSION, (int) EUnrealEngineObjectUE5Version.AUTOMATIC_VERSION)
                 };
             }

--- a/CUE4Parse/UE4/Versions/ObjectVersion.cs
+++ b/CUE4Parse/UE4/Versions/ObjectVersion.cs
@@ -33,6 +33,9 @@ namespace CUE4Parse.UE4.Versions
         // Replace FName asset path in FSoftObjectPath with (package name, asset name) pair FTopLevelAssetPath
         FSOFTOBJECTPATH_REMOVE_ASSET_PATH_FNAMES,
 
+        // Add a soft object path list to the package summary for fast remap
+        ADD_SOFTOBJECTPATH_LIST,
+
         // -----<new versions can be added before this line>-------------------------------------------------
         // - this needs to be the last line (see note below)
         AUTOMATIC_VERSION_PLUS_ONE,


### PR DESCRIPTION
Implementation for ObjectVersion ADD_SOFTOBJECTPATH_LIST in FPackageFileSummary

Reference:
https://github.com/EpicGames/UnrealEngine/blob/release/Engine/Source/Runtime/CoreUObject/Private/UObject/PackageFileSummary.cpp#L217

I couldn't figure out how the values are used, but with this they will at least be read properly and not mess up the rest of the summary

I think at least, I haven't been able to test it, but I think it looks right based on the UE source code