### PR TITLE
Allow Explicit LocalizedString Definition

### DIFF
--- a/CUE4Parse/UE4/Objects/Core/i18N/FText.cs
+++ b/CUE4Parse/UE4/Objects/Core/i18N/FText.cs
@@ -132,10 +132,10 @@ namespace CUE4Parse.UE4.Objects.Core.i18N
             };
         }
 
-        public FText(string sourceString) : this("", "", sourceString) { }
+        public FText(string sourceString, string localizedString = "") : this("", "", sourceString, localizedString) { }
 
-        public FText(string @namespace, string key, string sourceString) : this(0, ETextHistoryType.Base,
-            new FTextHistory.Base(@namespace, key, sourceString)) { }
+        public FText(string @namespace, string key, string sourceString, string localizedString = "") : this(0, ETextHistoryType.Base,
+            new FTextHistory.Base(@namespace, key, sourceString, localizedString)) { }
 
         public FText(uint flags, ETextHistoryType historyType, FTextHistory textHistory)
         {
@@ -203,12 +203,12 @@ namespace CUE4Parse.UE4.Objects.Core.i18N
                 LocalizedString = Ar.Owner.Provider?.GetLocalizedString(Namespace, Key, SourceString) ?? string.Empty;
             }
 
-            public Base(string namespacee, string key, string sourceString)
+            public Base(string namespacee, string key, string sourceString, string localizedString = "")
             {
                 Namespace = namespacee;
                 Key = key;
                 SourceString = sourceString;
-                LocalizedString = string.Empty;
+                LocalizedString = string.IsNullOrEmpty(localizedString) ? sourceString : localizedString;
             }
         }
 


### PR DESCRIPTION
Allows LocalizedString to be set when explicitly making an FText, if the localized string is null or empty it defaults to SourceString.

Main reason was to fix the Text property of FText being empty since the localized string was always set to string.Empty when creating an FTextHistory.Base