### PR TITLE
Fix loading of static meshes from Hogwarts Legacy

### DIFF
--- a/CUE4Parse/UE4/Assets/Exports/StaticMesh/UStaticMesh.cs
+++ b/CUE4Parse/UE4/Assets/Exports/StaticMesh/UStaticMesh.cs
@@ -54,6 +54,11 @@ namespace CUE4Parse.UE4.Assets.Exports.StaticMesh
             Sockets = Ar.ReadArray(() => new FPackageIndex(Ar));
             RenderData = new FStaticMeshRenderData(Ar, bCooked);
 
+            if (Ar.Game == EGame.GAME_HogwartsLegacy)
+            {
+                Ar.Position += 64;  // Skip 64 bytes of unknown data in Hogwarts Legacy's static meshes
+            }
+
             if (bCooked && Ar.Game is >= EGame.GAME_UE4_20 and < EGame.GAME_UE5_0)
             {
                 var bHasOccluderData = Ar.ReadBoolean();

--- a/CUE4Parse/UE4/Versions/EGame.cs
+++ b/CUE4Parse/UE4/Versions/EGame.cs
@@ -59,6 +59,7 @@ namespace CUE4Parse.UE4.Versions
         GAME_UE4_27 = GameUtils.GameUe4Base + 27 << 4,
             GAME_Splitgate = GAME_UE4_27 + 1,
             GAME_HYENAS = GAME_UE4_27 + 2,
+            GAME_HogwartsLegacy = GAME_UE4_27 + 3,
         GAME_UE4_28 = GameUtils.GameUe4Base + 28 << 4,
 
         GAME_UE4_LATEST = GAME_UE4_28,


### PR DESCRIPTION
This change fixes compatibility with Hogwarts Legacy game (based on Unreal Engine 4.27.2)
where this game's static meshes contain additional 64 bytes of data of (as of now) unkonwn purpose. 

Just skipping them works and the models are able to be exported and previewed just fine, for details see issue https://github.com/4sval/FModel/issues/357 where I originally raised this issue.

This commit was tested working with latest version of FModel on dev branch commit #[f3c1103](https://github.com/4sval/FModel/commit/f3c1103b0cf57ffd91bb688297b18829dfd65d0a)