### PR TITLE
Exporter QoL

### DIFF
--- a/CUE4Parse-Conversion/Animations/AnimExporter.cs
+++ b/CUE4Parse-Conversion/Animations/AnimExporter.cs
@@ -160,7 +160,10 @@ namespace CUE4Parse_Conversion.Animations
             }
 
             // psa file is done
-            AnimSequences.Add(new Anim($"{PackagePath}_SEQ{seqIdx}.psa", Ar.GetBuffer()));
+            AnimSequences.Add(seqIdx > 0
+                ? new Anim($"{PackagePath}_SEQ{seqIdx}.psa", Ar.GetBuffer())
+                : new Anim($"{PackagePath}.psa", Ar.GetBuffer()));
+
             Ar.Dispose();
         }
 

--- a/CUE4Parse-Conversion/IExporter.cs
+++ b/CUE4Parse-Conversion/IExporter.cs
@@ -23,6 +23,7 @@ namespace CUE4Parse_Conversion
         public ETexturePlatform Platform;
         public ESocketFormat SocketFormat;
         public bool ExportMorphTargets;
+        public bool ExportMaterials;
 
         public ExporterOptions()
         {
@@ -33,6 +34,7 @@ namespace CUE4Parse_Conversion
             Platform = ETexturePlatform.DesktopMobile;
             SocketFormat = ESocketFormat.Bone;
             ExportMorphTargets = true;
+            ExportMaterials = true;
         }
     }
 

--- a/CUE4Parse-Conversion/Meshes/MeshExporter.cs
+++ b/CUE4Parse-Conversion/Meshes/MeshExporter.cs
@@ -42,7 +42,7 @@ namespace CUE4Parse_Conversion.Meshes
             MeshLods.Add(new Mesh($"{PackagePath}.psk", Ar.GetBuffer(), new List<MaterialExporter2>()));
         }
 
-        public MeshExporter(UStaticMesh originalMesh, ExporterOptions options, bool exportMaterials = true) : base(originalMesh, options)
+        public MeshExporter(UStaticMesh originalMesh, ExporterOptions options) : base(originalMesh, options)
         {
             MeshLods = new List<Mesh>();
 
@@ -63,7 +63,7 @@ namespace CUE4Parse_Conversion.Meshes
                 }
 
                 using var Ar = new FArchiveWriter();
-                var materialExports = exportMaterials ? new List<MaterialExporter2>() : null;
+                var materialExports = options.ExportMaterials ? new List<MaterialExporter2>() : null;
                 string ext;
                 switch (Options.MeshFormat)
                 {
@@ -82,13 +82,20 @@ namespace CUE4Parse_Conversion.Meshes
                     default:
                         throw new ArgumentOutOfRangeException(nameof(Options.MeshFormat), Options.MeshFormat, null);
                 }
-
-                MeshLods.Add(new Mesh($"{PackagePath}_LOD{i}.{ext}", Ar.GetBuffer(), materialExports ?? new List<MaterialExporter2>()));
-                if (Options.LodFormat == ELodFormat.FirstLod) break;
+                
+                if (Options.LodFormat == ELodFormat.FirstLod)
+                {
+                    MeshLods.Add(new Mesh($"{PackagePath}.{ext}", Ar.GetBuffer(), materialExports ?? new List<MaterialExporter2>()));
+                    break;
+                }
+                else
+                {
+                    MeshLods.Add(new Mesh($"{PackagePath}_LOD{i}.{ext}", Ar.GetBuffer(), materialExports ?? new List<MaterialExporter2>()));
+                }
             }
         }
 
-        public MeshExporter(USkeletalMesh originalMesh, ExporterOptions options, bool exportMaterials = true) : base(originalMesh, options)
+        public MeshExporter(USkeletalMesh originalMesh, ExporterOptions options) : base(originalMesh, options)
         {
             MeshLods = new List<Mesh>();
 
@@ -119,7 +126,7 @@ namespace CUE4Parse_Conversion.Meshes
                 }
 
                 using var Ar = new FArchiveWriter();
-                var materialExports = exportMaterials ? new List<MaterialExporter2>() : null;
+                var materialExports = options.ExportMaterials ? new List<MaterialExporter2>() : null;
                 var ext = "";
                 switch (Options.MeshFormat)
                 {
@@ -142,8 +149,15 @@ namespace CUE4Parse_Conversion.Meshes
                         throw new ArgumentOutOfRangeException(nameof(Options.MeshFormat), Options.MeshFormat, null);
                 }
 
-                MeshLods.Add(new Mesh($"{PackagePath}_LOD{i}.{ext}", Ar.GetBuffer(), materialExports ?? new List<MaterialExporter2>()));
-                if (Options.LodFormat == ELodFormat.FirstLod) break;
+                if (Options.LodFormat == ELodFormat.FirstLod)
+                {
+                    MeshLods.Add(new Mesh($"{PackagePath}.{ext}", Ar.GetBuffer(), materialExports ?? new List<MaterialExporter2>()));
+                    break;
+                }
+                else
+                {
+                    MeshLods.Add(new Mesh($"{PackagePath}_LOD{i}.{ext}", Ar.GetBuffer(), materialExports ?? new List<MaterialExporter2>()));
+                }
                 i++;
             }
         }


### PR DESCRIPTION
It doesn't make any sense to change the exported mesh/anim's name to something different when many processes of modding pipelines relies on having the name be the same as the original, unless it needs to export multiple versions of the same asset, i.e. LODs or sequence indexes. 

@MinshuG any objections to updating this? If needs be (for backward compatibility reasons or whatever), I can add an option to have the new behaviour disabled by default, just let me know.

I also added an option for exporting materials, as currently it is always set to true with no way to change it...
