### PR TITLE
fix GLTF error for when there are no morphTargets present

### DIFF
--- a/CUE4Parse-Conversion/Meshes/Gltf.cs
+++ b/CUE4Parse-Conversion/Meshes/Gltf.cs
@@ -77,7 +77,7 @@ namespace CUE4Parse_Conversion.Meshes
                 }
 
                 targetNames += "]}";
-                mesh.Extras = JsonContent.Parse(targetNames);
+                mesh.Extras = morphTargets.Length > 0 ? JsonContent.Parse(targetNames) : null;
             }
 
             var sceneBuilder = new SceneBuilder();


### PR DESCRIPTION
Some models, such as ones from Snowbreak Containment Zone have an empty list of morphTargets it appears (or there may be an issue elsewhere reading the files correctly) but if there are no actual morphTargets present, this will throw an exception and break execution. This change makes it gracefully handle the lack of morphTargets instead of encountering an exception of `Object reference not set to an instance of an object.`