### PR TITLE
Fix for PSA sequences incorrectly reporting the FirstRawFrame

### DIFF
--- a/CUE4Parse-Conversion/Animations/AnimExporter.cs
+++ b/CUE4Parse-Conversion/Animations/AnimExporter.cs
@@ -96,7 +96,7 @@ namespace CUE4Parse_Conversion.Animations
                 TrackTime = sequence.NumFrames,
                 AnimRate = sequence.FramesPerSecond,
                 StartBone = 0, // reserved
-                FirstRawFrame = sequence.NumFrames, // useless, but used in UnrealEd when importing
+                FirstRawFrame = 0, // useless, but used in UnrealEd when importing
                 NumRawFrames = sequence.NumFrames
             };
             animInfo.Serialize(Ar);


### PR DESCRIPTION
This fixes https://github.com/FabianFG/CUE4Parse/issues/103.