### PR TITLE
Switch to FName for ShaderPlatform

### DIFF
--- a/CUE4Parse/UE4/Assets/Exports/Material/MaterialResourceTypes.cs
+++ b/CUE4Parse/UE4/Assets/Exports/Material/MaterialResourceTypes.cs
@@ -61,7 +61,7 @@ namespace CUE4Parse.UE4.Assets.Exports.Material
             var bShareCode = Ar.ReadBoolean();
             if (bUseNewFormat)
             {
-                var shaderPlatform = Ar.Game >= EGame.GAME_UE5_2 ? Ar.ReadFString() : Ar.Read<EShaderPlatform>().ToString();
+                var shaderPlatform = Ar.Game >= EGame.GAME_UE5_2 ? Ar.ReadFName() : Ar.Read<EShaderPlatform>().ToString();
             }
 
             if (bShareCode)


### PR DESCRIPTION
Using `Ar.ReadFString()` is invalid (at least on the UE5.2 game I am testing with), it should be an `FName`

excerpt from Unreal Code:

```cpp
bool bShareCode = false;
Ar << bShareCode;

FName ShaderPlatformName;
Ar << ShaderPlatformName;
```