### PR TITLE
L2KD PartGraph

### DIFF
--- a/CUE4Parse/FileProvider/AbstractFileProvider.cs
+++ b/CUE4Parse/FileProvider/AbstractFileProvider.cs
@@ -81,7 +81,7 @@ namespace CUE4Parse.FileProvider
                                     }
                                 }
                             }
-                            else if (!string.IsNullOrWhiteSpace(g.Value))
+                            else if (!string.IsNullOrWhiteSpace(g.Value) && g.Value != "{GameName}")
                             {
                                 _gameDisplayName = g.Value;
                             }

--- a/CUE4Parse/GameTypes/L2KD/Objects/FLegoGraphPartInstance.cs
+++ b/CUE4Parse/GameTypes/L2KD/Objects/FLegoGraphPartInstance.cs
@@ -1,0 +1,20 @@
+using CUE4Parse.UE4;
+using CUE4Parse.UE4.Assets.Readers;
+using System.Runtime.InteropServices;
+
+namespace CUE4Parse.GameTypes.L2KD.Objects
+{
+    [StructLayout(LayoutKind.Sequential)]
+    public readonly struct FLegoGraphPartInstance : IUStruct
+    {
+        public readonly uint Id;
+        public readonly uint Color;
+
+        public FLegoGraphPartInstance(FAssetArchive Ar) {
+            Id = Ar.Read<uint>();
+            Color = Ar.Read<uint>();
+        }
+
+        public override string ToString() => $"{nameof(Id)}: {Id}, {nameof(Color)}: {Color}";
+    }
+}

--- a/CUE4Parse/UE4/Assets/Objects/UScriptStruct.cs
+++ b/CUE4Parse/UE4/Assets/Objects/UScriptStruct.cs
@@ -1,6 +1,7 @@
 using CUE4Parse.GameTypes.FN.Objects;
 using CUE4Parse.GameTypes.SWJS.Objects;
 using CUE4Parse.GameTypes.TSW.Objects;
+using CUE4Parse.GameTypes.L2KD.Objects;
 using CUE4Parse.UE4.Assets.Exports.Engine.Font;
 using CUE4Parse.UE4.Assets.Exports.Material;
 using CUE4Parse.UE4.Assets.Exports.SkeletalMesh;
@@ -151,6 +152,9 @@ namespace CUE4Parse.UE4.Assets.Objects
                 "RsBitfield_WorldMapLODLevel" => new FRsBitfield(Ar, structName),
                 "RsBitfield_WorldMapWidgetFilterType" => new FRsBitfield(Ar, structName),
 
+                // Lego 2K Drive
+                "LegoGraphPartInstance" => type == ReadType.ZERO ? new FLegoGraphPartInstance() : new FLegoGraphPartInstance(Ar),
+				
                 _ => type == ReadType.ZERO ? new FStructFallback() : struc != null ? new FStructFallback(Ar, struc) : new FStructFallback(Ar, structName)
             };
         }


### PR DESCRIPTION
- Add support for `PartGraphInstance` Struct used in Lego 2K Drive
- Allow GameDisplayName to use alternate search if previous returned `{GameName} `