### PR TITLE
fix not parsing of FTextHistory.NamedFormat arguments

### DIFF
--- a/CUE4Parse/UE4/Objects/Core/i18N/FText.cs
+++ b/CUE4Parse/UE4/Objects/Core/i18N/FText.cs
@@ -209,8 +209,9 @@ namespace CUE4Parse.UE4.Objects.Core.i18N
             public NamedFormat(FAssetArchive Ar)
             {
                 SourceFmt = new FText(Ar);
-                Arguments = new Dictionary<string, FFormatArgumentValue>(Ar.Read<int>());
-                for (int i = 0; i < Arguments.Count; i++)
+                int ArgCount = Ar.Read<int>();
+                Arguments = new Dictionary<string, FFormatArgumentValue>(ArgCount);
+                for (int i = 0; i < ArgCount; i++)
                 {
                     Arguments[Ar.ReadFString()] = new FFormatArgumentValue(Ar);
                 }


### PR DESCRIPTION
due to mixing up Dictionary `Capacity` with `Count`