### PR TITLE
Support Usmap CEXT, PPTH, and ENVP

### DIFF
--- a/CUE4Parse/MappingsProvider/JsonTypeMappingsProvider.cs
+++ b/CUE4Parse/MappingsProvider/JsonTypeMappingsProvider.cs
@@ -85,7 +85,7 @@ namespace CUE4Parse.MappingsProvider
                 if (entry == null) continue;
                 var values = entry["values"]!.ToObject<string[]>()!;
                 var i = 0;
-                MappingsForGame.Enums[entry["name"]!.ToObject<string>()!] = values.ToDictionary(it => i++);
+                MappingsForGame.Enums[entry["name"]!.ToObject<string>()!] = values.ToDictionary(it => i++).Select(x => ((long) x.Key, x.Value)).ToList();
             }
         }
     }

--- a/CUE4Parse/MappingsProvider/MappingsSchema.cs
+++ b/CUE4Parse/MappingsProvider/MappingsSchema.cs
@@ -11,6 +11,7 @@ namespace CUE4Parse.MappingsProvider
         public readonly TypeMappings? Context;
         public string Name;
         public string? SuperType;
+        public string? Module;
         public Lazy<Struct?> Super;
         public Dictionary<int, PropertyInfo> Properties;
         public int PropertyCount;
@@ -51,7 +52,7 @@ namespace CUE4Parse.MappingsProvider
 
     public class SerializedStruct : Struct
     {
-        public SerializedStruct(TypeMappings? context, UStruct struc) : base(context, struc.Name, struc.ChildProperties.Length)
+        public SerializedStruct(TypeMappings? context, UStruct struc, string? name = null) : base(context, name ?? struc.Name, struc.ChildProperties.Length)
         {
             Super = new Lazy<Struct?>(() =>
             {

--- a/CUE4Parse/MappingsProvider/TypeMappings.cs
+++ b/CUE4Parse/MappingsProvider/TypeMappings.cs
@@ -5,18 +5,12 @@ namespace CUE4Parse.MappingsProvider
     public class TypeMappings
     {
         public readonly Dictionary<string, Struct> Types;
-        public readonly Dictionary<string, Dictionary<int, string>> Enums;
-
-        public TypeMappings(Dictionary<string, Struct> types, Dictionary<string, Dictionary<int, string>> enums)
-        {
-            Types = types;
-            Enums = enums;
-        }
+        public readonly Dictionary<string, List<(long, string)>> Enums;
 
         public TypeMappings()
         {
             Types = new Dictionary<string, Struct>();
-            Enums = new Dictionary<string, Dictionary<int, string>>();
+            Enums = new Dictionary<string, List<(long, string)>>();
         }
     }
 }

--- a/CUE4Parse/UE4/Assets/Objects/FStructFallback.cs
+++ b/CUE4Parse/UE4/Assets/Objects/FStructFallback.cs
@@ -25,7 +25,7 @@ namespace CUE4Parse.UE4.Assets.Objects
             if (Ar.HasUnversionedProperties)
             {
                 if (structType == null) throw new ArgumentException("For unversioned struct fallback the struct type cannot be null", nameof(structType));
-                UObject.DeserializePropertiesUnversioned(Properties = new List<FPropertyTag>(), Ar, structType);
+                UObject.DeserializePropertiesUnversioned(Properties = new List<FPropertyTag>(), Ar, structType, null /* ? */);
             }
             else
             {

--- a/CUE4Parse/UE4/Assets/Objects/Properties/EnumProperty.cs
+++ b/CUE4Parse/UE4/Assets/Objects/Properties/EnumProperty.cs
@@ -51,11 +51,15 @@ namespace CUE4Parse.UE4.Assets.Objects.Properties
                 return string.Concat(enumName, "::", index);
             }
 
-            if (Ar.Owner.Mappings != null &&
-                Ar.Owner.Mappings.Enums.TryGetValue(enumName, out var values) &&
-                values.TryGetValue(index, out var member))
+            if (Ar.Owner?.Mappings != null &&
+                Ar.Owner.Mappings.Enums.TryGetValue(enumName, out var values)) 
             {
-                return string.Concat(enumName, "::", member);
+                foreach (var (value, member) in values) 
+                {
+                    if (value == index) {
+                        return string.Concat(enumName, "::", member);
+                    }
+                }
             }
 
             return string.Concat(enumName, "::", index);

--- a/CUE4Parse/UE4/Assets/Package.cs
+++ b/CUE4Parse/UE4/Assets/Package.cs
@@ -392,6 +392,7 @@ namespace CUE4Parse.UE4.Assets
                 {
                     _object.Outer = _package;
                 }
+                _object.ClassIndex = _export.ClassIndex;
                 _object.Super = _package.ResolvePackageIndex(_export.SuperIndex) as ResolvedExportObject;
                 _object.Template = _package.ResolvePackageIndex(_export.TemplateIndex) as ResolvedExportObject;
                 _object.Flags |= (EObjectFlags) _export.ObjectFlags; // We give loaded objects the RF_WasLoaded flag in ConstructObject, so don't remove it again in here

--- a/CUE4Parse/UE4/Objects/Engine/UUserDefinedStruct.cs
+++ b/CUE4Parse/UE4/Objects/Engine/UUserDefinedStruct.cs
@@ -40,7 +40,8 @@ namespace CUE4Parse.UE4.Objects.Engine
 
             if (Ar.HasUnversionedProperties)
             {
-                DeserializePropertiesUnversioned(DefaultProperties = new List<FPropertyTag>(), Ar, this);
+                var name = ClassIndex?.ResolvedObject?.Outer?.Name;
+                DeserializePropertiesUnversioned(DefaultProperties = new List<FPropertyTag>(), Ar, this, name?.PlainText);
             }
             else
             {


### PR DESCRIPTION
PPTH is used to give structs and enums path names for deduplication when the name matches mutliple structs. (i.e. most AnimGeneratedBlueprints)

ENVP is used for non-linear enum values, usually bitsets or flags.