### PR TITLE
Fix FColor.Hex always adding alpha unless it's actually 1

### DIFF
--- a/CUE4Parse/UE4/Objects/Core/Math/FColor.cs
+++ b/CUE4Parse/UE4/Objects/Core/Math/FColor.cs
@@ -19,7 +19,7 @@ namespace CUE4Parse.UE4.Objects.Core.Math
         public readonly byte R;
         public readonly byte A;
 
-        public string Hex => A is 1 or 0 ? UnsafePrint.BytesToHex(R, G, B) : UnsafePrint.BytesToHex(A, R, G, B);
+        public string Hex => A is byte.MaxValue or 0 ? UnsafePrint.BytesToHex(R, G, B) : UnsafePrint.BytesToHex(A, R, G, B);
 
         public FColor(byte r, byte g, byte b, byte a)
         {


### PR DESCRIPTION
Pretty straightforward fix, instead of comparing to 1 it compares against 255.