### PR TITLE
Fix for Potionomics TMap

### DIFF
--- a/CUE4Parse/UE4/Assets/Objects/Properties/ByteProperty.cs
+++ b/CUE4Parse/UE4/Assets/Objects/Properties/ByteProperty.cs
@@ -14,7 +14,9 @@ namespace CUE4Parse.UE4.Assets.Objects.Properties
             {
                 ReadType.ZERO => 0,
                 ReadType.NORMAL => Ar.Read<byte>(),
-                ReadType.MAP when Ar.Game is EGame.GAME_Potionomics => (byte) Ar.Read<ulong>(),
+                ReadType.MAP when Ar.Versions["ByteProperty.TMap64Bit"] => (byte) Ar.Read<ulong>(),
+                ReadType.MAP when Ar.Versions["ByteProperty.TMap16Bit"] => (byte) Ar.Read<ushort>(),
+                ReadType.MAP when Ar.Versions["ByteProperty.TMap8Bit"] => Ar.Read<byte>(),
                 ReadType.MAP => (byte) Ar.Read<uint>(),
                 ReadType.ARRAY => Ar.Read<byte>(),
                 _ => throw new ArgumentOutOfRangeException(nameof(type), type, null)

--- a/CUE4Parse/UE4/Assets/Objects/Properties/ByteProperty.cs
+++ b/CUE4Parse/UE4/Assets/Objects/Properties/ByteProperty.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using CUE4Parse.UE4.Readers;
+using CUE4Parse.UE4.Versions;
 using Newtonsoft.Json;
 
 namespace CUE4Parse.UE4.Assets.Objects.Properties
@@ -13,6 +14,7 @@ namespace CUE4Parse.UE4.Assets.Objects.Properties
             {
                 ReadType.ZERO => 0,
                 ReadType.NORMAL => Ar.Read<byte>(),
+                ReadType.MAP when Ar.Game is EGame.GAME_Potionomics => (byte) Ar.Read<ulong>(),
                 ReadType.MAP => (byte) Ar.Read<uint>(),
                 ReadType.ARRAY => Ar.Read<byte>(),
                 _ => throw new ArgumentOutOfRangeException(nameof(type), type, null)

--- a/CUE4Parse/UE4/Versions/EGame.cs
+++ b/CUE4Parse/UE4/Versions/EGame.cs
@@ -45,6 +45,7 @@ namespace CUE4Parse.UE4.Versions
         GAME_UE4_23 = GameUtils.GameUe4Base + 23 << 4,
             GAME_ApexLegendsMobile = GAME_UE4_23 + 1,
         GAME_UE4_24 = GameUtils.GameUe4Base + 24 << 4,
+            GAME_Potionomics = GAME_UE4_24 + 1,
         GAME_UE4_25 = GameUtils.GameUe4Base + 25 << 4,
             GAME_UE4_25_Plus = GAME_UE4_25 + 1,
             GAME_RogueCompany = GAME_UE4_25 + 2,

--- a/CUE4Parse/UE4/Versions/EGame.cs
+++ b/CUE4Parse/UE4/Versions/EGame.cs
@@ -45,7 +45,6 @@ namespace CUE4Parse.UE4.Versions
         GAME_UE4_23 = GameUtils.GameUe4Base + 23 << 4,
             GAME_ApexLegendsMobile = GAME_UE4_23 + 1,
         GAME_UE4_24 = GameUtils.GameUe4Base + 24 << 4,
-            GAME_Potionomics = GAME_UE4_24 + 1,
         GAME_UE4_25 = GameUtils.GameUe4Base + 25 << 4,
             GAME_UE4_25_Plus = GAME_UE4_25 + 1,
             GAME_RogueCompany = GAME_UE4_25 + 2,

--- a/CUE4Parse/UE4/Versions/VersionContainer.cs
+++ b/CUE4Parse/UE4/Versions/VersionContainer.cs
@@ -86,6 +86,11 @@ namespace CUE4Parse.UE4.Versions
             Options["SoundWave.UseAudioStreaming"] = Game >= GAME_UE4_25 && Game != GAME_UE4_28 && Game != GAME_GTATheTrilogyDefinitiveEdition && Game != GAME_ReadyOrNot && Game != GAME_BladeAndSoul; // A lot of games use this, but some don't, which causes issues.
             Options["AnimSequence.HasCompressedRawSize"] = Game >= GAME_UE4_17; // Early 4.17 builds don't have this, and some custom engine builds don't either.
             Options["StaticMesh.HasNavCollision"] = Ver >= EUnrealEngineObjectUE4Version.STATIC_MESH_STORE_NAV_COLLISION && Game != GAME_GearsOfWar4 && Game != GAME_TEKKEN7;
+            
+            // special general property workarounds
+            Options["ByteProperty.TMap64Bit"] = false;
+            Options["ByteProperty.TMap16Bit"] = false;
+            Options["ByteProperty.TMap8Bit"] = false;
 
             // defaults
             Options["SkeletalMesh.KeepMobileMinLODSettingOnDesktop"] = false;


### PR DESCRIPTION
Fixes #97 

It is possible that TMap can be overriden but automated TMap struct override dumpers did not find this, and dumping the entire game did not find any issues.