### PR TITLE
UScriptMapConverter creating arrays instead of objects

### DIFF
--- a/CUE4Parse/JsonConverters.cs
+++ b/CUE4Parse/JsonConverters.cs
@@ -956,30 +956,26 @@ public class UScriptMapConverter : JsonConverter<UScriptMap>
 {
     public override void WriteJson(JsonWriter writer, UScriptMap value, JsonSerializer serializer)
     {
-        writer.WriteStartArray();
+        writer.WriteStartObject();
 
         foreach (var kvp in value.Properties)
         {
             switch (kvp.Key)
             {
                 case StructProperty:
-                    writer.WriteStartObject();
                     writer.WritePropertyName("Key");
                     serializer.Serialize(writer, kvp.Key);
                     writer.WritePropertyName("Value");
                     serializer.Serialize(writer, kvp.Value);
-                    writer.WriteEndObject();
                     break;
                 default:
-                    writer.WriteStartObject();
                     writer.WritePropertyName(kvp.Key.ToString().SubstringBefore('(').Trim());
                     serializer.Serialize(writer, kvp.Value);
-                    writer.WriteEndObject();
                     break;
             }
         }
 
-        writer.WriteEndArray();
+        writer.WriteEndObject();
     }
 
     public override UScriptMap ReadJson(JsonReader reader, Type objectType, UScriptMap existingValue, bool hasExistingValue,

--- a/CUE4Parse/UE4/Assets/Objects/UScriptArray.cs
+++ b/CUE4Parse/UE4/Assets/Objects/UScriptArray.cs
@@ -26,6 +26,12 @@ namespace CUE4Parse.UE4.Assets.Objects
         {
             InnerType = tagData?.InnerType ?? throw new ParserException(Ar, "UScriptArray needs inner type");
             var elementCount = Ar.Read<int>();
+            if (elementCount > Ar.Length - Ar.Position)
+            {
+                throw new ParserException(Ar,
+                    $"ArrayProperty element count {elementCount} is larger than the remaining archive size {Ar.Length - Ar.Position}");
+            }
+
             if (Ar.HasUnversionedProperties)
             {
                 InnerTagData = tagData.InnerTypeData;

--- a/CUE4Parse/UE4/Readers/FArchive.cs
+++ b/CUE4Parse/UE4/Readers/FArchive.cs
@@ -282,6 +282,11 @@ namespace CUE4Parse.UE4.Readers
             if (length == int.MinValue)
                 throw new ArgumentOutOfRangeException(nameof(length), "Archive is corrupted");
 
+            if (Math.Abs(length) > Length - Position)
+            {
+                throw new ParserException($"Invalid FString length '{length}'");
+            }
+
             // if (length is < -512000 or > 512000)
             //     throw new ParserException($"Invalid FString length '{length}'");
 


### PR DESCRIPTION
It causes the maps serialized as arrays instead of dictionaries.
Also added some checks to avoid CLR crashes and unnecessary creation of huge arrays.