### PR TITLE
Fix for StructProperty key/values for UScriptMapConverter serialization

### DIFF
--- a/CUE4Parse/JsonConverters.cs
+++ b/CUE4Parse/JsonConverters.cs
@@ -960,19 +960,8 @@ public class UScriptMapConverter : JsonConverter<UScriptMap>
 
         foreach (var kvp in value.Properties)
         {
-            switch (kvp.Key)
-            {
-                case StructProperty:
-                    writer.WritePropertyName("Key");
-                    serializer.Serialize(writer, kvp.Key);
-                    writer.WritePropertyName("Value");
-                    serializer.Serialize(writer, kvp.Value);
-                    break;
-                default:
-                    writer.WritePropertyName(kvp.Key.ToString().SubstringBefore('(').Trim());
-                    serializer.Serialize(writer, kvp.Value);
-                    break;
-            }
+            writer.WritePropertyName(kvp.Key.ToString().SubstringBefore('(').Trim());
+            serializer.Serialize(writer, kvp.Value);
         }
 
         writer.WriteEndObject();


### PR DESCRIPTION
It fixes the the object creation problem for Struct types in https://github.com/FabianFG/CUE4Parse/pull/124