### PR TITLE
fix UScriptMap converter

### DIFF
--- a/CUE4Parse/JsonConverters.cs
+++ b/CUE4Parse/JsonConverters.cs
@@ -958,10 +958,29 @@ public class UScriptMapConverter : JsonConverter<UScriptMap>
     {
         writer.WriteStartObject();
 
+        var index = 0;
         foreach (var kvp in value.Properties)
         {
-            writer.WritePropertyName(kvp.Key.ToString().SubstringBefore('(').Trim());
-            serializer.Serialize(writer, kvp.Value);
+            index++;
+            switch (kvp.Key)
+            {
+                case StructProperty structProperty:
+                    if (structProperty.Value!.StructType.GetType().GetMethod("ToString")!.DeclaringType != typeof(object))
+                    {
+                        writer.WritePropertyName(structProperty.Value!.StructType.ToString()!);
+                    }
+                    else
+                    {
+                        writer.WritePropertyName($"MapEntry{index}Key");
+                        serializer.Serialize(writer, kvp.Key);
+                        writer.WritePropertyName($"MapEntry{index}Value");
+                    }
+                    serializer.Serialize(writer, kvp.Value);
+                default:
+                    writer.WritePropertyName(kvp.Key.ToString().SubstringBefore('(').Trim());
+                    serializer.Serialize(writer, kvp.Value);
+                    break;
+            }
         }
 
         writer.WriteEndObject();


### PR DESCRIPTION
#124 and #125 uses `kvp.Key.ToString()` which will return `StructName (StructProperty)` (as defined in `UScriptStruct.ToString`) and be trimmed to `StructName`. 

The solution is to use `Value.StructType`, which will still exhibit this behavior for structs that do not have `ToString()` overriden, which the bit of reflection checks against and falls back to the legacy behavior.

For struct types that are used as the key (which usually is a GUID), it's probably best to try and implement ToString for those.