### PR TITLE
Chunked patch readers for large files

### DIFF
--- a/CUE4Parse/Globals.cs
+++ b/CUE4Parse/Globals.cs
@@ -9,5 +9,6 @@ namespace CUE4Parse
         public static bool LogVfsMounts = true;
         public static bool FatalObjectSerializationErrors = false;
         public static bool WarnMissingImportPackage = true;
+        public static bool AlwaysUseChunkedReader = false;
     }
 }

--- a/CUE4Parse/UE4/IO/IoStoreReader.cs
+++ b/CUE4Parse/UE4/IO/IoStoreReader.cs
@@ -199,7 +199,7 @@ namespace CUE4Parse.UE4.IO
             throw new KeyNotFoundException($"Couldn't find chunk {chunkId} in IoStore {Name}");
         }
 
-        private byte[] Read(long offset, long length)
+        public byte[] Read(long offset, long length)
         {
             var compressionBlockSize = TocResource.Header.CompressionBlockSize;
             var dst = new byte[length];

--- a/CUE4Parse/UE4/IO/Objects/FIoStoreEntry.cs
+++ b/CUE4Parse/UE4/IO/Objects/FIoStoreEntry.cs
@@ -39,6 +39,6 @@ namespace CUE4Parse.UE4.IO.Objects
         public override byte[] Read() => Vfs.Extract(this);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public override FArchive CreateReader() => new FByteArchive(Path, Read(), Vfs.Versions);
+        public override FArchive CreateReader() => Size > int.MaxValue || Globals.AlwaysUseChunkedReader ? new FIoChunkArchive(Path, this, Vfs.Versions) :  new FByteArchive(Path, Read(), Vfs.Versions);
     }
 }

--- a/CUE4Parse/UE4/Pak/Objects/FPakEntry.cs
+++ b/CUE4Parse/UE4/Pak/Objects/FPakEntry.cs
@@ -328,6 +328,6 @@ namespace CUE4Parse.UE4.Pak.Objects
         public override byte[] Read() => Vfs.Extract(this);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public override FArchive CreateReader() => new FByteArchive(Path, Read(), Vfs.Versions);
+        public override FArchive CreateReader() => Size > int.MaxValue || Globals.AlwaysUseChunkedReader ? new FPakChunkArchive(Path, this, Vfs.Versions) :  new FByteArchive(Path, Read(), Vfs.Versions);
     }
 }

--- a/CUE4Parse/UE4/Pak/PakFileReader.cs
+++ b/CUE4Parse/UE4/Pak/PakFileReader.cs
@@ -272,62 +272,64 @@ namespace CUE4Parse.UE4.Pak
             Ar.Dispose();
         }
 
-        public Span<byte> Read(FPakEntry pakEntry, long offset, long size) {
+        public Span<byte> Read(FPakEntry pakEntry, long offset, long size)
+        {
             // If this reader is used as a concurrent reader create a clone of the main reader to provide thread safety
-            var reader = IsConcurrent ? (FArchive) Ar.Clone() : Ar;
+            var reader = IsConcurrent ? (FArchive)Ar.Clone() : Ar;
             if (pakEntry.IsCompressed)
             {
 #if DEBUG
                 Log.Debug($"{pakEntry.Name} is compressed with {pakEntry.CompressionMethod}");
 #endif
-                var uncompressed = new byte[(int) size + pakEntry.CompressionBlockSize];
+                var uncompressed = new byte[(int)size + pakEntry.CompressionBlockSize];
                 var uncompressedOff = 0;
                 var shift = 0;
                 foreach (var block in pakEntry.CompressionBlocks)
                 {
-                    if (offset >= block.Size) {
+                    if (offset >= block.Size)
+                    {
                         offset -= block.Size;
                         continue;
                     }
 
-                    if (offset != 0) {
-                        shift = (int) offset;
-                    }
+                    if (offset != 0)
+                        shift = (int)offset;
 
                     offset = 0;
                     reader.Position = block.CompressedStart;
-                    var blockSize = (int) block.Size;
+                    var blockSize = (int)block.Size;
                     var srcSize = blockSize.Align(pakEntry.IsEncrypted ? Aes.ALIGN : 1);
                     // Read the compressed block
                     byte[] compressed = ReadAndDecrypt(srcSize, reader, pakEntry.IsEncrypted);
                     // Calculate the uncompressed size,
                     // its either just the compression block size
                     // or if its the last block its the remaining data size
-                    var uncompressedSize = (int) Math.Min(pakEntry.CompressionBlockSize, size - uncompressedOff);
+                    var uncompressedSize = (int)Math.Min(pakEntry.CompressionBlockSize, size - uncompressedOff);
                     Decompress(compressed, 0, blockSize, uncompressed, uncompressedOff, uncompressedSize, pakEntry.CompressionMethod);
-                    uncompressedOff += (int) pakEntry.CompressionBlockSize;
+                    uncompressedOff += (int)pakEntry.CompressionBlockSize;
 
-                    if (uncompressedOff >= uncompressed.Length) {
+                    if (uncompressedOff >= uncompressed.Length)
                         break;
-                    }
                 }
 
-                return uncompressed.AsSpan(shift, (int) size);
+                return uncompressed.AsSpan(shift, (int)size);
             }
 
             // Pak Entry is written before the file data,
             // but its the same as the one from the index, just without a name
             // We don't need to serialize that again so + file.StructSize
-            var readSize = (int) size.Align(pakEntry.IsEncrypted ? Aes.ALIGN : 1);
+            var readSize = (int)size.Align(pakEntry.IsEncrypted ? Aes.ALIGN : 1);
             var readShift = 0;
-            if (pakEntry.IsEncrypted && offset.Align(Aes.ALIGN) != offset) {
+            if (pakEntry.IsEncrypted && offset.Align(Aes.ALIGN) != offset)
+            {
                 var tmp = offset.Align(Aes.ALIGN) - Aes.ALIGN;
                 readShift = (int)(offset - tmp);
                 offset = tmp;
                 readSize += Aes.ALIGN;
             }
+
             reader.Position = pakEntry.Offset + offset + pakEntry.StructSize; // Doesn't seem to be the case with older pak versions
-            return ReadAndDecrypt(readSize, reader, pakEntry.IsEncrypted).AsSpan(readShift, (int) size);
+            return ReadAndDecrypt(readSize, reader, pakEntry.IsEncrypted).AsSpan(readShift, (int)size);
         }
     }
 }

--- a/CUE4Parse/UE4/Readers/FChunkedArchive.cs
+++ b/CUE4Parse/UE4/Readers/FChunkedArchive.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Buffers;
+using System.IO;
+using System.Runtime.CompilerServices;
+using CUE4Parse.UE4.Versions;
+using CUE4Parse.Utils;
+
+namespace CUE4Parse.UE4.Readers;
+
+public abstract class FChunkedArchive : FArchive {
+    private const int BUFFER_SIZE = 1024 * 1024 * 128; // 128 MiB.
+
+    protected FChunkedArchive(string path, VersionContainer versions) : base(versions) {
+        Name = path;
+        Buffer = ArrayPool<byte>.Shared.Rent(BUFFER_SIZE);
+    }
+
+    protected abstract Span<byte> ReadChunks(long offset, long size);
+
+    public override int Read(byte[] buffer, int offset, int count) {
+        if (Position < 0) {
+            return 0;
+        }
+
+        var n = (int) (Length - Position);
+        if (n > count) n = count;
+        if (n <= 0)
+            return 0;
+
+        Span<byte> data;
+        if (n < BUFFER_SIZE) {
+            var bufferRangeStart = BufferOffset;
+            var bufferRangeEnd = BufferOffset + BUFFER_SIZE;
+            if (!(bufferRangeStart <= Position && Position <= bufferRangeEnd)) {
+                BufferOffset = Position;
+                var blockSize = Math.Min(BUFFER_SIZE, Length - Position).Align(BUFFER_SIZE);
+                if (Position.Align(BUFFER_SIZE) != Position) {
+                    BufferOffset = Position.Align(BUFFER_SIZE) - BUFFER_SIZE;
+                }
+
+                ReadChunks(BufferOffset, blockSize).CopyTo(Buffer);
+            }
+
+            data = Buffer.AsSpan().Slice((int)(Position - BufferOffset), n);
+        } else {
+            data = ReadChunks(Position, n);
+        }
+
+        data.CopyTo(buffer.AsSpan(offset));
+        Position += n;
+        return n;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public override long Seek(long offset, SeekOrigin origin)
+    {
+        Position = origin switch
+                   {
+                       SeekOrigin.Begin   => offset,
+                       SeekOrigin.Current => Position + offset,
+                       SeekOrigin.End     => Length + offset,
+                       _                  => throw new ArgumentOutOfRangeException()
+                   };
+        return Position;
+    }
+
+    public override bool CanSeek => true;
+    public override long Position { get; set; }
+    public override string Name { get; }
+    private byte[] Buffer { get; }
+    private long BufferOffset { get; set; } = -BUFFER_SIZE - 1;
+
+    protected void ImportBuffer(FChunkedArchive other) {
+        BufferOffset = other.BufferOffset;
+        other.Buffer.AsSpan().CopyTo(Buffer.AsSpan());
+    }
+
+    public override void Close() {
+        base.Close();
+        ArrayPool<byte>.Shared.Return(Buffer);
+    }
+}

--- a/CUE4Parse/UE4/Readers/FChunkedArchive.cs
+++ b/CUE4Parse/UE4/Readers/FChunkedArchive.cs
@@ -7,42 +7,47 @@ using CUE4Parse.Utils;
 
 namespace CUE4Parse.UE4.Readers;
 
-public abstract class FChunkedArchive : FArchive {
+public abstract class FChunkedArchive : FArchive
+{
     private const int BUFFER_SIZE = 1024 * 1024 * 128; // 128 MiB.
 
-    protected FChunkedArchive(string path, VersionContainer versions) : base(versions) {
+    protected FChunkedArchive(string path, VersionContainer versions) : base(versions)
+    {
         Name = path;
         Buffer = ArrayPool<byte>.Shared.Rent(BUFFER_SIZE);
     }
 
     protected abstract Span<byte> ReadChunks(long offset, long size);
 
-    public override int Read(byte[] buffer, int offset, int count) {
-        if (Position < 0) {
+    public override int Read(byte[] buffer, int offset, int count)
+    {
+        if (Position < 0)
             return 0;
-        }
 
-        var n = (int) (Length - Position);
+        var n = (int)(Length - Position);
         if (n > count) n = count;
         if (n <= 0)
             return 0;
 
         Span<byte> data;
-        if (n < BUFFER_SIZE) {
+        if (n < BUFFER_SIZE)
+        {
             var bufferRangeStart = BufferOffset;
             var bufferRangeEnd = BufferOffset + BUFFER_SIZE;
-            if (!(bufferRangeStart <= Position && Position <= bufferRangeEnd)) {
+            if (!(bufferRangeStart <= Position && Position <= bufferRangeEnd))
+            {
                 BufferOffset = Position;
                 var blockSize = Math.Min(BUFFER_SIZE, Length - Position).Align(BUFFER_SIZE);
-                if (Position.Align(BUFFER_SIZE) != Position) {
+                if (Position.Align(BUFFER_SIZE) != Position)
                     BufferOffset = Position.Align(BUFFER_SIZE) - BUFFER_SIZE;
-                }
 
                 ReadChunks(BufferOffset, blockSize).CopyTo(Buffer);
             }
 
             data = Buffer.AsSpan().Slice((int)(Position - BufferOffset), n);
-        } else {
+        }
+        else
+        {
             data = ReadChunks(Position, n);
         }
 
@@ -55,12 +60,12 @@ public abstract class FChunkedArchive : FArchive {
     public override long Seek(long offset, SeekOrigin origin)
     {
         Position = origin switch
-                   {
-                       SeekOrigin.Begin   => offset,
-                       SeekOrigin.Current => Position + offset,
-                       SeekOrigin.End     => Length + offset,
-                       _                  => throw new ArgumentOutOfRangeException()
-                   };
+        {
+            SeekOrigin.Begin => offset,
+            SeekOrigin.Current => Position + offset,
+            SeekOrigin.End => Length + offset,
+            _ => throw new ArgumentOutOfRangeException()
+        };
         return Position;
     }
 
@@ -70,12 +75,14 @@ public abstract class FChunkedArchive : FArchive {
     private byte[] Buffer { get; }
     private long BufferOffset { get; set; } = -BUFFER_SIZE - 1;
 
-    protected void ImportBuffer(FChunkedArchive other) {
+    protected void ImportBuffer(FChunkedArchive other)
+    {
         BufferOffset = other.BufferOffset;
         other.Buffer.AsSpan().CopyTo(Buffer.AsSpan());
     }
 
-    public override void Close() {
+    public override void Close()
+    {
         base.Close();
         ArrayPool<byte>.Shared.Return(Buffer);
     }

--- a/CUE4Parse/UE4/Readers/FIoChunkArchive.cs
+++ b/CUE4Parse/UE4/Readers/FIoChunkArchive.cs
@@ -4,22 +4,28 @@ using CUE4Parse.UE4.Versions;
 
 namespace CUE4Parse.UE4.Readers;
 
-public class FIoChunkArchive : FChunkedArchive {
-    public FIoChunkArchive(string path, FIoStoreEntry entry, VersionContainer versions) : base(path, versions) {
+public class FIoChunkArchive : FChunkedArchive
+{
+    public FIoChunkArchive(string path, FIoStoreEntry entry, VersionContainer versions) : base(path, versions)
+    {
         Entry = entry;
     }
 
     public override long Length => Entry.Size;
     public FIoStoreEntry Entry { get; }
-    public override object Clone() {
-        var instance = new FIoChunkArchive(Name, Entry, Versions) {
+
+    public override object Clone()
+    {
+        var instance = new FIoChunkArchive(Name, Entry, Versions)
+        {
             Position = Position,
         };
         instance.ImportBuffer(this);
         return instance;
     }
 
-    protected override Span<byte> ReadChunks(long offset, long size) {
+    protected override Span<byte> ReadChunks(long offset, long size)
+    {
         var remaining = Math.Min(size, Entry.Size - offset);
         return remaining <= 0 ? Span<byte>.Empty : Entry.IoStoreReader.Read(offset + Entry.Offset, remaining);
     }

--- a/CUE4Parse/UE4/Readers/FIoChunkArchive.cs
+++ b/CUE4Parse/UE4/Readers/FIoChunkArchive.cs
@@ -1,0 +1,26 @@
+using System;
+using CUE4Parse.UE4.IO.Objects;
+using CUE4Parse.UE4.Versions;
+
+namespace CUE4Parse.UE4.Readers;
+
+public class FIoChunkArchive : FChunkedArchive {
+    public FIoChunkArchive(string path, FIoStoreEntry entry, VersionContainer versions) : base(path, versions) {
+        Entry = entry;
+    }
+
+    public override long Length => Entry.Size;
+    public FIoStoreEntry Entry { get; }
+    public override object Clone() {
+        var instance = new FIoChunkArchive(Name, Entry, Versions) {
+            Position = Position,
+        };
+        instance.ImportBuffer(this);
+        return instance;
+    }
+
+    protected override Span<byte> ReadChunks(long offset, long size) {
+        var remaining = Math.Min(size, Entry.Size - offset);
+        return remaining <= 0 ? Span<byte>.Empty : Entry.IoStoreReader.Read(offset + Entry.Offset, remaining);
+    }
+}

--- a/CUE4Parse/UE4/Readers/FPakChunkArchive.cs
+++ b/CUE4Parse/UE4/Readers/FPakChunkArchive.cs
@@ -1,0 +1,26 @@
+using System;
+using CUE4Parse.UE4.Pak.Objects;
+using CUE4Parse.UE4.Versions;
+
+namespace CUE4Parse.UE4.Readers;
+
+public class FPakChunkArchive : FChunkedArchive {
+    public FPakChunkArchive(string path, FPakEntry entry, VersionContainer versions) : base(path, versions) {
+        Entry = entry;
+    }
+
+    public override long Length => Entry.UncompressedSize;
+    public FPakEntry Entry { get; }
+    public override object Clone() {
+        var instance = new FPakChunkArchive(Name, Entry, Versions) {
+            Position = Position,
+        };
+        instance.ImportBuffer(this);
+        return instance;
+    }
+
+    protected override Span<byte> ReadChunks(long offset, long size) {
+        var remaining = Math.Min(size, Entry.UncompressedSize - offset);
+        return remaining <= 0 ? Span<byte>.Empty : Entry.PakFileReader.Read(Entry, offset, remaining);
+    }
+}

--- a/CUE4Parse/UE4/Readers/FPakChunkArchive.cs
+++ b/CUE4Parse/UE4/Readers/FPakChunkArchive.cs
@@ -4,22 +4,28 @@ using CUE4Parse.UE4.Versions;
 
 namespace CUE4Parse.UE4.Readers;
 
-public class FPakChunkArchive : FChunkedArchive {
-    public FPakChunkArchive(string path, FPakEntry entry, VersionContainer versions) : base(path, versions) {
+public class FPakChunkArchive : FChunkedArchive
+{
+    public FPakChunkArchive(string path, FPakEntry entry, VersionContainer versions) : base(path, versions)
+    {
         Entry = entry;
     }
 
     public override long Length => Entry.UncompressedSize;
     public FPakEntry Entry { get; }
-    public override object Clone() {
-        var instance = new FPakChunkArchive(Name, Entry, Versions) {
+
+    public override object Clone()
+    {
+        var instance = new FPakChunkArchive(Name, Entry, Versions)
+        {
             Position = Position,
         };
         instance.ImportBuffer(this);
         return instance;
     }
 
-    protected override Span<byte> ReadChunks(long offset, long size) {
+    protected override Span<byte> ReadChunks(long offset, long size)
+    {
         var remaining = Math.Min(size, Entry.UncompressedSize - offset);
         return remaining <= 0 ? Span<byte>.Empty : Entry.PakFileReader.Read(Entry, offset, remaining);
     }


### PR DESCRIPTION
Allows large files to be read. The issue occurs because these files (usually .umaps) are over 2 GB which is too big for an array. This new reader loads the file in chunks stored in a 128 MB buffer.

This might prevent the issue described in #95.

I briefly tested this and it seems to work, but due to the minor refactor in PakFileReader, I'm not sure if I haven't introduced side-effects.

I'm currently testing out Palworld to see if it actually works, so the PR is a draft for now.