### PR TITLE
VersionedFileProvider

### DIFF
--- a/CUE4Parse/FileProvider/VersionedFileProvider.cs
+++ b/CUE4Parse/FileProvider/VersionedFileProvider.cs
@@ -1,0 +1,97 @@
+﻿#nullable disable
+using System;
+using System.IO;
+using System.Linq;
+using CUE4Parse.FileProvider.Objects;
+using CUE4Parse.FileProvider.Vfs;
+using CUE4Parse.UE4.IO.Objects;
+using CUE4Parse.UE4.Pak.Objects;
+using CUE4Parse.UE4.Versions;
+
+namespace CUE4Parse.FileProvider;
+
+public class VersionedFileProvider : DefaultFileProvider
+{
+    private FileProviderDictionary _originals;
+    private ILookup<string, VersionedGameFile> _versionedFilesLookup;
+    private StringComparer _comparer;
+
+    public VersionedFileProvider(string directory, SearchOption searchOption, bool isCaseInsensitive = false, VersionContainer versions = null) : base(
+        directory, searchOption, isCaseInsensitive, versions)
+    {
+    }
+
+    public VersionedFileProvider(DirectoryInfo directory, SearchOption searchOption, bool isCaseInsensitive = false, VersionContainer versions = null) : base(
+        directory, searchOption, isCaseInsensitive, versions)
+    {
+    }
+
+    public VersionedFileProvider(DirectoryInfo directory, DirectoryInfo[] extraDirectories, SearchOption searchOption, bool isCaseInsensitive = false,
+        VersionContainer versions = null) : base(directory, extraDirectories, searchOption, isCaseInsensitive, versions)
+    {
+    }
+
+    public void SetToAll()
+    {
+        Init();
+        _files.Clear();
+        _files.AddFiles(_originals);
+    }
+
+    public void SetToLatestFiles()
+    {
+        Init();
+
+        var dict = _versionedFilesLookup.ToDictionary(f => f.Key, f => f.MaxBy(vf => vf.Version).GameFile, _comparer);
+        _files.Clear();
+        _files.AddFiles(dict);
+    }
+
+    public void SetToVersion(int version)
+    {
+        Init();
+        var dict = _versionedFilesLookup.Where(f => f.Any(vf => vf.Version <= version))
+            .ToDictionary(f => f.Key, f => f.Where(vf => vf.Version <= version).MaxBy(vf => vf.Version).GameFile, _comparer);
+        _files.Clear();
+        _files.AddFiles(dict);
+    }
+
+
+    private void Init()
+    {
+        if (_originals == null)
+        {
+            _originals = new FileProviderDictionary(IsCaseInsensitive);
+            _originals.AddFiles(_files);
+        }
+
+        _comparer = IsCaseInsensitive ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase;
+        _versionedFilesLookup ??= _originals.ToLookup(f => f.Key, f => new VersionedGameFile(f.Value), _comparer);
+    }
+
+    private class VersionedGameFile(GameFile gameFile)
+    {
+        public GameFile GameFile { get; } = gameFile;
+        public int Version { get; } = GetVersionFromFile(gameFile);
+
+
+        private static int GetVersionFromFile(GameFile gameFile)
+        {
+            var packageFileName = gameFile switch
+            {
+                FPakEntry file => Path.GetFileNameWithoutExtension(file.PakFileReader.Name),
+                FIoStoreEntry floFile => Path.GetFileNameWithoutExtension(floFile.IoStoreReader.Name),
+                _ => throw new Exception("Unknown file type")
+            };
+
+            var entries = packageFileName.Split('_');
+            if (entries.Length < 3)
+                return -1;
+            if (entries[^1] != "P")
+                return -1;
+            if (!int.TryParse(entries[^2], out var version))
+                return -1;
+            return version;
+        }
+    }
+}

--- a/CUE4Parse/UE4/Readers/FArchive.cs
+++ b/CUE4Parse/UE4/Readers/FArchive.cs
@@ -99,6 +99,10 @@ namespace CUE4Parse.UE4.Readers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public T[] ReadArray<T>(int length, Func<T> getter)
         {
+            if (length > 1000000)
+            {
+                throw new ParserException($"FArchive.ReadArray huge array {length}");
+            }
             var result = new T[length];
 
             if (length == 0)
@@ -154,6 +158,9 @@ namespace CUE4Parse.UE4.Readers
         {
             var elementSize = Read<int>();
             var elementCount = Read<int>();
+            if (elementSize < 0 || elementSize > 10000000 || elementCount < 0 || elementCount > 10000000)
+                return Array.Empty<T>();
+                //throw new ParserException($"ReadBulkArray ElementSize {elementSize} ElementCount {elementCount}");
             return ReadBulkArray(elementSize, elementCount, getter);
         }
 


### PR DESCRIPTION
Adds a version aware file provider, which takes only the latest versions of files from mounted files.

Comes with 3 methods:
- `SetToAll`: Falls back to original behavior.
- `SetToLatest`: Updates the Files dictionary with only the latest versions of the files.
- `SetToVersion`: Same as SetToLatest, except it ignores any files above the version.

These methods should be called after the mount.

DefaultFileProvider:
![image](https://github.com/FabianFG/CUE4Parse/assets/93623214/cd1981b9-0feb-4db1-98f7-dcf5fd7f8534)

VersionedFileProvider:
![image](https://github.com/FabianFG/CUE4Parse/assets/93623214/dd8108b2-09f7-40f9-9a73-d0da28157b0e)
