### PR TITLE
Remove hardcoded limit of 4 bone weight influences

### DIFF
--- a/CUE4Parse-Conversion/Meshes/MeshConverter.cs
+++ b/CUE4Parse-Conversion/Meshes/MeshConverter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using CUE4Parse.UE4.Assets.Exports.Animation;
 using CUE4Parse.UE4.Assets.Exports.SkeletalMesh;
 using CUE4Parse.UE4.Assets.Exports.StaticMesh;
@@ -265,21 +266,14 @@ namespace CUE4Parse_Conversion.Meshes
                         skeletalMeshLod.VertexColors[vert] = srcLod.ColorVertexBuffer.Data[vert];
                     }
 
-                    var i2 = 0;
-                    uint packedWeights = 0;
-                    var len = Math.Min(v.Infs.BoneWeight.Length, 4);
-                    for (var j = 0; j < len; j++)
+                    foreach (var (weight, boneIndex) in v.Infs.BoneWeight.Zip(v.Infs.BoneIndex))
                     {
-                        uint boneWeight = v.Infs.BoneWeight[j];
-                        if (boneWeight == 0) continue; // skip this influence (but do not stop the loop!)
-
-                        packedWeights |= boneWeight << (i2 * 8);
-                        skeletalMeshLod.Verts[vert].Bone[i2] = (short) boneMap[v.Infs.BoneIndex[j]];
-                        i2++;
+                        if (weight != 0)
+                        {
+                            var bone = (short)boneMap[boneIndex];
+                            skeletalMeshLod.Verts[vert].AddInfluence(bone, weight);
+                        }
                     }
-
-                    skeletalMeshLod.Verts[vert].PackedWeights = packedWeights;
-                    if (i2 < 4) skeletalMeshLod.Verts[vert].Bone[i2] = -1; // mark end of list
                 }
 
                 convertedMesh.LODs.Add(skeletalMeshLod);

--- a/CUE4Parse-Conversion/Meshes/PSK/BoneInfluence.cs
+++ b/CUE4Parse-Conversion/Meshes/PSK/BoneInfluence.cs
@@ -1,0 +1,6 @@
+﻿namespace CUE4Parse_Conversion.Meshes.PSK;
+
+public record BoneInfluence(short Bone, byte RawWeight)
+{
+    public float Weight => RawWeight / 255.0f;
+}

--- a/CUE4Parse-Conversion/Meshes/PSK/CSkelMeshVertex.cs
+++ b/CUE4Parse-Conversion/Meshes/PSK/CSkelMeshVertex.cs
@@ -1,4 +1,5 @@
-﻿using CUE4Parse.UE4.Objects.Core.Math;
+﻿using System.Collections.Generic;
+using CUE4Parse.UE4.Objects.Core.Math;
 using CUE4Parse.UE4.Objects.Meshes;
 using CUE4Parse.UE4.Objects.RenderCore;
 
@@ -6,23 +7,17 @@ namespace CUE4Parse_Conversion.Meshes.PSK
 {
     public class CSkelMeshVertex : CMeshVertex
     {
-        public uint PackedWeights;
-        public short[]? Bone;
-
+        private readonly List<BoneInfluence> _influences = [];
+        
         public CSkelMeshVertex(FVector position, FPackedNormal normal, FPackedNormal tangent, FMeshUVFloat uv) : base(position, normal, tangent, uv)
         {
-            Bone = new short[4];
         }
 
-        public float[] UnpackWeights()
+        public IReadOnlyList<BoneInfluence> Influences => _influences;
+
+        public void AddInfluence(short bone, byte weight)
         {
-            var ret = new float[4];
-            var scale = 1.0f / 255;
-            ret[0] =  (PackedWeights        & 0xFF) * scale;
-            ret[1] = ((PackedWeights >> 8 ) & 0xFF) * scale;
-            ret[2] = ((PackedWeights >> 16) & 0xFF) * scale;
-            ret[3] = ((PackedWeights >> 24) & 0xFF) * scale;
-            return ret;
+            _influences.Add(new BoneInfluence(bone, weight));
         }
     }
 }

--- a/CUE4Parse-Conversion/Meshes/UEFormat/UEModel.cs
+++ b/CUE4Parse-Conversion/Meshes/UEFormat/UEModel.cs
@@ -139,25 +139,17 @@ public class UEModel : UEFormatExport
 
     private void SerializeSkeletalMeshData(CSkelMeshVertex[] verts, FPackageIndex[]? morphTargets, int lodIndex)
     {
-        // TODO can we work on getting unlimited influences, no more psk restrictions !!
         using (var weightsChunk = new FDataChunk("WEIGHTS"))
         {
             for (var vertexIndex = 0; vertexIndex < verts.Length; vertexIndex++)
             {
                 var vert = verts[vertexIndex];
-            
-                var vertBones = vert.Bone;
-                if (vertBones is null) continue;
-            
-                var weights = vert.UnpackWeights();
-                for (var index = 0; index < weights.Length; index++)
+                
+                foreach (var influence in vert.Influences)
                 {
-                    var weight = weights[index];
-                    if (weight <= 0) continue;
-                    
-                    weightsChunk.Write(vertBones[index]);
+                    weightsChunk.Write(influence.Bone);
                     weightsChunk.Write(vertexIndex);
-                    weightsChunk.Write(weight);
+                    weightsChunk.Write(influence.Weight);
                     weightsChunk.Count++;
                 }
             }

--- a/CUE4Parse-Conversion/Meshes/glTF/Gltf.cs
+++ b/CUE4Parse-Conversion/Meshes/glTF/Gltf.cs
@@ -231,18 +231,14 @@ namespace CUE4Parse_Conversion.Meshes.glTF
 
         public static VertexJoints4 PrepareVertexJoint(CSkelMeshVertex vert)
         {
-            var weights = vert.UnpackWeights();
-            var j1 = new List<(int, float)>();
+            var bindings = new List<(int, float)>();
 
-            if (weights.All((v) => v == 0) || vert.Bone == null)
-                return new VertexJoints4(j1.ToArray());
-
-            for (int i = 0; i < vert.Bone.Length; i++)
+            foreach (var influence in vert.Influences)
             {
-                j1.Add((vert.Bone[i], weights[i]));
+                bindings.Add((influence.Bone, influence.Weight));
             }
-
-            return new VertexJoints4(j1.ToArray());
+            
+            return new VertexJoints4(bindings.ToArray());
         }
 
         public static (VertexJoints4, VertexJoints4, VertexJoints4) PrepareVertexJoints(CSkelMeshVertex vert1, CSkelMeshVertex vert2, CSkelMeshVertex vert3)


### PR DESCRIPTION
This PR aims to remove the hardcoded limit of 4 bone weight influences.

I have tested it manually on a few skeletal meshes from a game that use 8 bone weight influences, and it seems to work.

However, I couldn't try out the glTF export, since it seems to be broken on the current master branch (throws a NullReferenceException when exporting)?
