### PR TITLE
Fixed parsing of `Curves` data in `PoseContainer`

### DIFF
--- a/CUE4Parse-Conversion/Animations/UEFormat/UEAnim.cs
+++ b/CUE4Parse-Conversion/Animations/UEFormat/UEAnim.cs
@@ -84,7 +84,7 @@ public class UEAnim : UEFormatExport
             foreach (var floatCurve in floatCurves)
             {
                 // TODO serialize more data for better accuracy
-                curveChunk.WriteFString(floatCurve.Name.DisplayName.Text);
+                curveChunk.WriteFString(floatCurve.CurveName.Text);
                 curveChunk.Write(floatCurve.FloatCurve.Keys.Length);
                 foreach (var floatCurveKey in floatCurve.FloatCurve.Keys)
                 {

--- a/CUE4Parse/UE4/Assets/Exports/Animation/AnimCurveCompressionCodec_CompressedRichCurve.cs
+++ b/CUE4Parse/UE4/Assets/Exports/Animation/AnimCurveCompressionCodec_CompressedRichCurve.cs
@@ -210,7 +210,7 @@ namespace CUE4Parse.UE4.Assets.Exports.Animation
                     var rawCurve = ConverterMap[(int) curve.CompressionFormat][(int) curve.KeyTimeCompressionFormat](curve.PreInfinityExtrap, curve.PostInfinityExtrap, curve.NumKeys, compressedKeys);
                     floatCurves[curveIndex] = new FFloatCurve
                     {
-                        CurveName = curveName,
+                        CurveName = curveName.DisplayName,
                         FloatCurve = rawCurve,
                         CurveTypeFlags = 4
                     };

--- a/CUE4Parse/UE4/Assets/Exports/Animation/AnimCurveCompressionCodec_CompressedRichCurve.cs
+++ b/CUE4Parse/UE4/Assets/Exports/Animation/AnimCurveCompressionCodec_CompressedRichCurve.cs
@@ -210,7 +210,7 @@ namespace CUE4Parse.UE4.Assets.Exports.Animation
                     var rawCurve = ConverterMap[(int) curve.CompressionFormat][(int) curve.KeyTimeCompressionFormat](curve.PreInfinityExtrap, curve.PostInfinityExtrap, curve.NumKeys, compressedKeys);
                     floatCurves[curveIndex] = new FFloatCurve
                     {
-                        Name = curveName,
+                        CurveName = curveName,
                         FloatCurve = rawCurve,
                         CurveTypeFlags = 4
                     };

--- a/CUE4Parse/UE4/Assets/Exports/Animation/AnimCurveTypes.cs
+++ b/CUE4Parse/UE4/Assets/Exports/Animation/AnimCurveTypes.cs
@@ -28,7 +28,6 @@ namespace CUE4Parse.UE4.Assets.Exports.Animation
         }
     }
 
-    [StructFallback]
     public class FFloatCurve : FAnimCurveBase
     {
         public FRichCurve FloatCurve;
@@ -41,7 +40,6 @@ namespace CUE4Parse.UE4.Assets.Exports.Animation
         }
     }
 
-    [StructFallback]
     public struct FRawCurveTracks
     {
         public FFloatCurve[]? FloatCurves;

--- a/CUE4Parse/UE4/Assets/Exports/Animation/AnimCurveTypes.cs
+++ b/CUE4Parse/UE4/Assets/Exports/Animation/AnimCurveTypes.cs
@@ -1,6 +1,8 @@
 ﻿using CUE4Parse.UE4.Assets.Objects;
+using CUE4Parse.UE4.Assets.Utils;
 using CUE4Parse.UE4.Objects.Engine.Animation;
 using CUE4Parse.UE4.Objects.Engine.Curves;
+using CUE4Parse.UE4.Objects.UObject;
 
 namespace CUE4Parse.UE4.Assets.Exports.Animation
 {
@@ -11,20 +13,22 @@ namespace CUE4Parse.UE4.Assets.Exports.Animation
         AACF_Metadata = 0x00000010,
     }
 
+    [StructFallback]
     public class FAnimCurveBase
     {
-        public FSmartName Name;
+        public FName CurveName;
         public int CurveTypeFlags; // Should be editor only
 
         public FAnimCurveBase() { }
 
         public FAnimCurveBase(FStructFallback data)
         {
-            Name = data.GetOrDefault<FSmartName>(nameof(Name));
+            CurveName = data.GetOrDefault<FName>(nameof(CurveName));
             CurveTypeFlags = data.GetOrDefault<int>(nameof(CurveTypeFlags));
         }
     }
 
+    [StructFallback]
     public class FFloatCurve : FAnimCurveBase
     {
         public FRichCurve FloatCurve;
@@ -37,6 +41,7 @@ namespace CUE4Parse.UE4.Assets.Exports.Animation
         }
     }
 
+    [StructFallback]
     public struct FRawCurveTracks
     {
         public FFloatCurve[]? FloatCurves;

--- a/CUE4Parse/UE4/Assets/Exports/Animation/UAnimSequence.cs
+++ b/CUE4Parse/UE4/Assets/Exports/Animation/UAnimSequence.cs
@@ -26,7 +26,7 @@ namespace CUE4Parse.UE4.Assets.Exports.Animation
 
         #region FCompressedAnimSequence CompressedData
         public FTrackToSkeletonMap[] CompressedTrackToSkeletonMapTable; // used for compressed data, missing before 4.12
-        public FName[] CompressedCurveNames;
+        public FSmartName[] CompressedCurveNames;
         //public byte[] CompressedByteStream; The actual data will be in CompressedDataStructure, no need to store as field
         public byte[]? CompressedCurveByteStream;
         public FRawCurveTracks CompressedCurveData; // disappeared in 4.23
@@ -224,7 +224,7 @@ namespace CUE4Parse.UE4.Assets.Exports.Animation
             }
             else
             {
-                CompressedCurveNames = Ar.ReadArray(Ar.ReadFName);
+                CompressedCurveNames = Ar.ReadArray(() => new FSmartName(Ar));
             }
 
             if (Ar.Versions["AnimSequence.HasCompressedRawSize"])
@@ -277,7 +277,7 @@ namespace CUE4Parse.UE4.Assets.Exports.Animation
         {
             CompressedRawDataSize = Ar.Read<int>();
             CompressedTrackToSkeletonMapTable = Ar.ReadArray<FTrackToSkeletonMap>();
-            CompressedCurveNames = Ar.ReadArray(Ar.ReadFName);
+            CompressedCurveNames = Ar.ReadArray(() => new FSmartName(Ar));
 
             var compressedData = new FUECompressedAnimData();
             CompressedDataStructure = compressedData;
@@ -298,7 +298,7 @@ namespace CUE4Parse.UE4.Assets.Exports.Animation
         {
             CompressedRawDataSize = Ar.Read<int>();
             CompressedTrackToSkeletonMapTable = Ar.ReadArray<FTrackToSkeletonMap>();
-            CompressedCurveNames = Ar.ReadArray(Ar.ReadFName);
+            CompressedCurveNames = Ar.ReadArray(() => new FSmartName(Ar));
 
             var serializedByteStream = ReadSerializedByteStream(Ar);
 

--- a/CUE4Parse/UE4/Assets/Exports/Animation/UAnimSequence.cs
+++ b/CUE4Parse/UE4/Assets/Exports/Animation/UAnimSequence.cs
@@ -26,7 +26,7 @@ namespace CUE4Parse.UE4.Assets.Exports.Animation
 
         #region FCompressedAnimSequence CompressedData
         public FTrackToSkeletonMap[] CompressedTrackToSkeletonMapTable; // used for compressed data, missing before 4.12
-        public FSmartName[] CompressedCurveNames;
+        public FName[] CompressedCurveNames;
         //public byte[] CompressedByteStream; The actual data will be in CompressedDataStructure, no need to store as field
         public byte[]? CompressedCurveByteStream;
         public FRawCurveTracks CompressedCurveData; // disappeared in 4.23
@@ -224,7 +224,7 @@ namespace CUE4Parse.UE4.Assets.Exports.Animation
             }
             else
             {
-                CompressedCurveNames = Ar.ReadArray(() => new FSmartName(Ar));
+                CompressedCurveNames = Ar.ReadArray(Ar.ReadFName);
             }
 
             if (Ar.Versions["AnimSequence.HasCompressedRawSize"])
@@ -277,7 +277,7 @@ namespace CUE4Parse.UE4.Assets.Exports.Animation
         {
             CompressedRawDataSize = Ar.Read<int>();
             CompressedTrackToSkeletonMapTable = Ar.ReadArray<FTrackToSkeletonMap>();
-            CompressedCurveNames = Ar.ReadArray(() => new FSmartName(Ar));
+            CompressedCurveNames = Ar.ReadArray(Ar.ReadFName);
 
             var compressedData = new FUECompressedAnimData();
             CompressedDataStructure = compressedData;
@@ -298,7 +298,7 @@ namespace CUE4Parse.UE4.Assets.Exports.Animation
         {
             CompressedRawDataSize = Ar.Read<int>();
             CompressedTrackToSkeletonMapTable = Ar.ReadArray<FTrackToSkeletonMap>();
-            CompressedCurveNames = Ar.ReadArray(() => new FSmartName(Ar));
+            CompressedCurveNames = Ar.ReadArray(Ar.ReadFName);
 
             var serializedByteStream = ReadSerializedByteStream(Ar);
 


### PR DESCRIPTION
**Summary**

When working on https://github.com/halfuwu/FortnitePorting/pull/42, I noticed through the debugger that all entries in `FPoseDataContainer`'s `Curves` were null.

This PR provides a small patch to ensure `Curves` in `FPoseDataContainer` is properly parsed. Interestingly though, this data is parsed without any issues when conerted to JSON through FModel.