### PR TITLE
Include 'clamp' as valid function when evaluating expression data

### DIFF
--- a/CUE4Parse/UE4/Assets/Exports/Animation/CurveExpression/FExpressionEvaluator.cs
+++ b/CUE4Parse/UE4/Assets/Exports/Animation/CurveExpression/FExpressionEvaluator.cs
@@ -175,7 +175,7 @@ public static class GBuiltInFunctions
 
     public static bool IsValidFunctionIndex(int index)
     {
-        return index > 0 && index < Functions.Count;
+        return index >= 0 && index < Functions.Count;
     }
 
     public static FFunctionInfo GetInfoByIndex(int inIndex)


### PR DESCRIPTION
`clamp` is registered at index 0 in `GBuiltInFunctions` but was unintentionally being excluded as part of the check in `IsValidFunctionIndex`.