### PR TITLE
UTexture2DArray handling

### DIFF
--- a/CUE4Parse-Conversion/Textures/TextureDecoder.cs
+++ b/CUE4Parse-Conversion/Textures/TextureDecoder.cs
@@ -146,11 +146,12 @@ public static class TextureDecoder
             out var colorType);
 
         var bitmaps = new List<SKBitmap>();
+        var offset = sizeX * sizeY * 4;
         for (var i = 0; i < mip.SizeZ; i++)
         {
-            var offset = sizeX * sizeY * 4;
             var startIndex = offset * i;
             var endIndex = startIndex + offset;
+            if (endIndex > data.Length) break;
             bitmaps.Add(InstallPixels(data[startIndex..endIndex],
                 new SKImageInfo(sizeX, sizeY, colorType, SKAlphaType.Unpremul)));
         }

--- a/CUE4Parse-Conversion/Textures/TextureDecoder.cs
+++ b/CUE4Parse-Conversion/Textures/TextureDecoder.cs
@@ -127,12 +127,12 @@ public static class TextureDecoder
         return null;
     }
 
-    public static List<SKBitmap>? DecodeTextureArray(this UTexture2DArray texture, ETexturePlatform platform = ETexturePlatform.DesktopMobile)
+    public static SKBitmap[]? DecodeTextureArray(this UTexture2DArray texture, ETexturePlatform platform = ETexturePlatform.DesktopMobile)
     {
         var mip = texture.GetFirstMip();
 
         if (mip is null) return null;
-        
+
         var sizeX = mip.SizeX;
         var sizeY = mip.SizeY;
 
@@ -156,8 +156,7 @@ public static class TextureDecoder
                 new SKImageInfo(sizeX, sizeY, colorType, SKAlphaType.Unpremul)));
         }
 
-        return bitmaps;
-
+        return bitmaps.ToArray();
     }
 
     public static void DecodeTexture(FTexture2DMipMap? mip, int sizeX, int sizeY, int sizeZ, EPixelFormat format, bool isNormalMap, ETexturePlatform platform, out byte[] data, out SKColorType colorType)


### PR DESCRIPTION
Currently, a few textures in the Fortnite files are stored as UTexture2DArray objects, which pack multiple images into a single image with multiple layers.  For example, TA_Atlas_Figure_EyeAndLash_Char01 has 20 different textures packed into that single object.  

![image](https://github.com/FabianFG/CUE4Parse/assets/17242591/111a6d84-b0d4-4204-90c3-a083ceeec581)

This PR adds a new "DecodeTextureArray()" method that decodes and returns an array of all textures contained in that object, and adds an optional "zLayer" parameter to the existing Decode() method which would allow for decoding a single layer instead of being locked to either the first layer or the entire set of layers