### PR TITLE
Archive read size checks

### DIFF
--- a/CUE4Parse/UE4/Readers/FArchive.cs
+++ b/CUE4Parse/UE4/Readers/FArchive.cs
@@ -40,10 +40,7 @@ namespace CUE4Parse.UE4.Readers
 
         public virtual byte[] ReadBytes(int length)
         {
-            if (Position + length > Length)
-            {
-                throw new ParserException(this, "Array size is bigger than remaining archive length.");
-            }
+            CheckReadSize(length);
 
             var result = new byte[length];
             Read(result, 0, length);
@@ -67,10 +64,7 @@ namespace CUE4Parse.UE4.Readers
         {
             var size = Unsafe.SizeOf<T>();
             var readLength = size * length;
-            if (Position + readLength > Length)
-            {
-                throw new ParserException(this, "Array size is bigger than remaining archive length.");
-            }
+            CheckReadSize(readLength);
 
             var buffer = ReadBytes(readLength);
             var result = new T[length];
@@ -83,10 +77,8 @@ namespace CUE4Parse.UE4.Readers
             if (array.Length == 0) return;
             var size = Unsafe.SizeOf<T>();
             var readLength = size * array.Length;
-            if (Position + readLength > Length)
-            {
-                throw new ParserException(this, "Array size is bigger than remaining archive length.");
-            }
+            CheckReadSize(readLength);
+
             var buffer = ReadBytes(readLength);
             Unsafe.CopyBlockUnaligned(ref Unsafe.As<T, byte>(ref array[0]), ref buffer[0], (uint)(readLength));
         }
@@ -506,6 +498,14 @@ namespace CUE4Parse.UE4.Readers
             value = ((value << 8) & 0xFF00FF00FF00FF00UL) | ((value >> 8) & 0x00FF00FF00FF00FFUL);
             value = ((value << 16) & 0xFFFF0000FFFF0000UL) | ((value >> 16) & 0x0000FFFF0000FFFFUL);
             return (value << 32) | (value >> 32);
+        }
+
+        public void CheckReadSize(int length)
+        {
+            if (Position + length > Length)
+            {
+                throw new ParserException(this, "Read size is bigger than remaining archive length.");
+            }
         }
 
         public abstract object Clone();

--- a/CUE4Parse/UE4/Readers/FByteArchive.cs
+++ b/CUE4Parse/UE4/Readers/FByteArchive.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Runtime.CompilerServices;
+using CUE4Parse.UE4.Exceptions;
 using CUE4Parse.UE4.Versions;
 
 namespace CUE4Parse.UE4.Readers
@@ -74,6 +75,10 @@ namespace CUE4Parse.UE4.Readers
         public override T[] ReadArray<T>(int length)
         {
             var size = length * Unsafe.SizeOf<T>();
+            if (Position + size > Length)
+            {
+                throw new ParserException(this, "Array size is bigger than archive size.");
+            }
             var result = new T[length];
             if (length > 0) Unsafe.CopyBlockUnaligned(ref Unsafe.As<T, byte>(ref result[0]), ref _data[Position], (uint) size);
             Position += size;
@@ -85,6 +90,10 @@ namespace CUE4Parse.UE4.Readers
         {
             if (array.Length == 0) return;
             var size = array.Length * Unsafe.SizeOf<T>();
+            if (Position + size > Length)
+            {
+                throw new ParserException(this, "Array size is bigger than archive size.");
+            }
             Unsafe.CopyBlockUnaligned(ref Unsafe.As<T, byte>(ref array[0]), ref _data[Position], (uint) size);
             Position += size;
         }

--- a/CUE4Parse/UE4/Readers/FByteArchive.cs
+++ b/CUE4Parse/UE4/Readers/FByteArchive.cs
@@ -75,10 +75,7 @@ namespace CUE4Parse.UE4.Readers
         public override T[] ReadArray<T>(int length)
         {
             var size = length * Unsafe.SizeOf<T>();
-            if (Position + size > Length)
-            {
-                throw new ParserException(this, "Array size is bigger than archive size.");
-            }
+            CheckReadSize(size);
             var result = new T[length];
             if (length > 0) Unsafe.CopyBlockUnaligned(ref Unsafe.As<T, byte>(ref result[0]), ref _data[Position], (uint) size);
             Position += size;
@@ -90,10 +87,7 @@ namespace CUE4Parse.UE4.Readers
         {
             if (array.Length == 0) return;
             var size = array.Length * Unsafe.SizeOf<T>();
-            if (Position + size > Length)
-            {
-                throw new ParserException(this, "Array size is bigger than archive size.");
-            }
+            CheckReadSize(size);
             Unsafe.CopyBlockUnaligned(ref Unsafe.As<T, byte>(ref array[0]), ref _data[Position], (uint) size);
             Position += size;
         }

--- a/CUE4Parse/UE4/Readers/FPointerArchive.cs
+++ b/CUE4Parse/UE4/Readers/FPointerArchive.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Runtime.CompilerServices;
+using CUE4Parse.UE4.Exceptions;
 using CUE4Parse.UE4.Versions;
 
 namespace CUE4Parse.UE4.Readers
@@ -72,6 +73,10 @@ namespace CUE4Parse.UE4.Readers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public override byte[] ReadBytes(int length)
         {
+            if (Position + length > Length)
+            {
+                throw new ParserException(this, "Array size is bigger than remaining archive length.");
+            }
             var buffer = new byte[length];
             Read(buffer, 0, length);
             return buffer;

--- a/CUE4Parse/UE4/Readers/FPointerArchive.cs
+++ b/CUE4Parse/UE4/Readers/FPointerArchive.cs
@@ -73,10 +73,7 @@ namespace CUE4Parse.UE4.Readers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public override byte[] ReadBytes(int length)
         {
-            if (Position + length > Length)
-            {
-                throw new ParserException(this, "Array size is bigger than remaining archive length.");
-            }
+            CheckReadSize(length);
             var buffer = new byte[length];
             Read(buffer, 0, length);
             return buffer;

--- a/CUE4Parse/UE4/Readers/FStreamArchive.cs
+++ b/CUE4Parse/UE4/Readers/FStreamArchive.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Runtime.CompilerServices;
+using CUE4Parse.UE4.Exceptions;
 using CUE4Parse.UE4.Versions;
 
 namespace CUE4Parse.UE4.Readers
@@ -38,6 +39,10 @@ namespace CUE4Parse.UE4.Readers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public override byte[] ReadBytes(int length)
         {
+            if (Position + length > Length)
+            {
+                throw new ParserException(this, "Array size is bigger than remaining archive length.");
+            }
             var result = new byte[length];
             _baseStream.Read(result, 0, length);
             return result;

--- a/CUE4Parse/UE4/Readers/FStreamArchive.cs
+++ b/CUE4Parse/UE4/Readers/FStreamArchive.cs
@@ -39,10 +39,7 @@ namespace CUE4Parse.UE4.Readers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public override byte[] ReadBytes(int length)
         {
-            if (Position + length > Length)
-            {
-                throw new ParserException(this, "Array size is bigger than remaining archive length.");
-            }
+            CheckReadSize(length);
             var result = new byte[length];
             _baseStream.Read(result, 0, length);
             return result;


### PR DESCRIPTION
Fail fast checks to prevent unnecessary array creations