### PR TITLE
Allow users to change the read type

### DIFF
--- a/CUE4Parse/UE4/Objects/UObject/ObjectResource.cs
+++ b/CUE4Parse/UE4/Objects/UObject/ObjectResource.cs
@@ -210,7 +210,7 @@ namespace CUE4Parse.UE4.Objects.UObject
             ObjectName = Ar.ReadFName();
             ObjectFlags = Ar.Read<uint>();
 
-            if (Ar.Ver < EUnrealEngineObjectUE4Version.e64BIT_EXPORTMAP_SERIALSIZES)
+            if (Ar.Ver < EUnrealEngineObjectUE4Version.e64BIT_EXPORTMAP_SERIALSIZES && !Ar.Versions["UObject.Use32Bit"])
             {
                 SerialSize = Ar.Read<int>();
                 SerialOffset = Ar.Read<int>();

--- a/CUE4Parse/UE4/Versions/VersionContainer.cs
+++ b/CUE4Parse/UE4/Versions/VersionContainer.cs
@@ -97,6 +97,7 @@ namespace CUE4Parse.UE4.Versions
 
             // defaults
             Options["StripAdditiveRefPose"] = false;
+            Options["UObject.Use32Bit"] = false;
             Options["SkeletalMesh.KeepMobileMinLODSettingOnDesktop"] = false;
             Options["StaticMesh.KeepMobileMinLODSettingOnDesktop"] = false;
 


### PR DESCRIPTION
some games have a version less than `e64BIT_EXPORTMAP_SERIALSIZES` but it still uses 32 bit