### PR TITLE
Marvel Rivals shader archive support

### DIFF
--- a/CUE4Parse/JsonConverters.cs
+++ b/CUE4Parse/JsonConverters.cs
@@ -158,6 +158,55 @@ public class FACLDatabaseCompressedAnimDataConverter : JsonConverter<FACLDatabas
     }
 }
 
+public class FSerializedShaderArchiveConverter_MarvelRivals : JsonConverter<FSerializedShaderArchive_MarvelRivals>
+{
+    public override void WriteJson(JsonWriter writer, FSerializedShaderArchive_MarvelRivals value, JsonSerializer serializer)
+    {
+        writer.WriteStartObject();
+
+        writer.WritePropertyName("ShaderMapHashes");
+        writer.WriteStartArray();
+        foreach (var shaderMapHash in value.ShaderMapHashes)
+        {
+            serializer.Serialize(writer, shaderMapHash.Hash);
+        }
+
+        writer.WriteEndArray();
+
+        writer.WritePropertyName("ShaderHashes");
+        writer.WriteStartArray();
+        foreach (var shaderHash in value.ShaderHashes)
+        {
+            serializer.Serialize(writer, shaderHash.Hash);
+        }
+
+        writer.WriteEndArray();
+
+        writer.WritePropertyName("Unk");
+        serializer.Serialize(writer, value.Unk);
+
+        writer.WritePropertyName("ShaderMapEntries");
+        serializer.Serialize(writer, value.ShaderMapEntries);
+
+        writer.WritePropertyName("ShaderEntries");
+        serializer.Serialize(writer, value.ShaderEntries);
+
+        writer.WritePropertyName("PreloadEntries");
+        serializer.Serialize(writer, value.PreloadEntries);
+
+        writer.WritePropertyName("ShaderIndices");
+        serializer.Serialize(writer, value.ShaderIndices);
+
+        writer.WriteEndObject();
+    }
+
+    public override FSerializedShaderArchive_MarvelRivals ReadJson(JsonReader reader, Type objectType, FSerializedShaderArchive_MarvelRivals existingValue, bool hasExistingValue,
+        JsonSerializer serializer)
+    {
+        throw new NotImplementedException();
+    }
+}
+
 public class FSerializedShaderArchiveConverter : JsonConverter<FSerializedShaderArchive>
 {
     public override void WriteJson(JsonWriter writer, FSerializedShaderArchive value, JsonSerializer serializer)

--- a/CUE4Parse/UE4/Shaders/FSerializedShaderArchive_MarvelRivals.cs
+++ b/CUE4Parse/UE4/Shaders/FSerializedShaderArchive_MarvelRivals.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using CUE4Parse.UE4.Objects.Core.Misc;
+using CUE4Parse.UE4.Readers;
+using CUE4Parse.Utils;
+using Newtonsoft.Json;
+
+namespace CUE4Parse.UE4.Shaders
+{
+    public readonly struct FSHA224 : IUStruct
+    {
+        public const int SIZE = 28;
+
+        public readonly byte[] Hash;
+
+        public FSHA224(FArchive Ar)
+        {
+            Hash = Ar.ReadBytes(SIZE);
+        }
+
+        public override string ToString()
+        {
+            unsafe { fixed (byte* ptr = Hash) { return UnsafePrint.BytesToHex(ptr, SIZE); } }
+        }
+    }
+
+    [JsonConverter(typeof(FSerializedShaderArchiveConverter_MarvelRivals))]
+    public class FSerializedShaderArchive_MarvelRivals : FRHIShaderLibrary
+    {
+        public readonly FSHAHash[] ShaderMapHashes;
+        public readonly FSHA224[] ShaderHashes;
+        public readonly uint Unk;
+        public readonly FShaderMapEntry[] ShaderMapEntries;
+        public readonly FShaderCodeEntry[] ShaderEntries;
+        public readonly FFileCachePreloadEntry[] PreloadEntries;
+        public readonly uint[] ShaderIndices;
+        // public readonly FHashTable ShaderMapHashTable;
+        // public readonly FHashTable ShaderHashTable;
+
+        public FSerializedShaderArchive_MarvelRivals(FArchive Ar)
+        {
+            ShaderMapHashes = Ar.ReadArray(() => new FSHAHash(Ar));
+            ShaderHashes = Ar.ReadArray(() => new FSHA224(Ar));
+            Unk = BitConverter.ToUInt32(Ar.ReadBytes(4));
+            ShaderMapEntries = Ar.ReadArray<FShaderMapEntry>();
+            ShaderEntries = Ar.ReadArray<FShaderCodeEntry>();
+            PreloadEntries = Ar.ReadArray<FFileCachePreloadEntry>();
+            ShaderIndices = Ar.ReadArray<uint>();
+        }
+    }
+}

--- a/CUE4Parse/UE4/Shaders/FShaderCodeArchive.cs
+++ b/CUE4Parse/UE4/Shaders/FShaderCodeArchive.cs
@@ -27,6 +27,18 @@ namespace CUE4Parse.UE4.Shaders
 
             switch (archiveVersion)
             {
+                case 2 when Ar.Game == EGame.GAME_MarvelRivals:
+                {
+                    var shaders = new FSerializedShaderArchive_MarvelRivals(Ar);
+                    ShaderCode = new byte[shaders.ShaderEntries.Length][];
+                    for (var i = 0; i < shaders.ShaderEntries.Length; i++)
+                    {
+                        ShaderCode[i] = Ar.ReadBytes((int) shaders.ShaderEntries[i].Size);
+                    }
+
+                    SerializedShaders = shaders;
+                    break;
+                }
                 case 2:
                 {
                     var shaders = new FSerializedShaderArchive(Ar);


### PR DESCRIPTION
Marvel Rivals uses SHA-224 for its shader hashes (NOT shader map hashes though), and has an additional unknown 4 bytes afterwards.