### PR TITLE
[feat] add ARK Ascended game type & configure offsets

### DIFF
--- a/CUE4Parse/UE4/Pak/Objects/FPakInfo.cs
+++ b/CUE4Parse/UE4/Pak/Objects/FPakInfo.cs
@@ -276,6 +276,7 @@ namespace CUE4Parse.UE4.Pak.Objects
             SizeRennsport = Size8a + 16,
             SizeQQ = Size8a + 26,
             SizeDbD = Size8a + 32, // additional 28 bytes for encryption key and 4 bytes for unknown uint
+            ARKSurvivalAscended = Size8a + 8, // additional 8 bytes 
 
             SizeLast,
             SizeMax = SizeLast - 1
@@ -320,6 +321,7 @@ namespace CUE4Parse.UE4.Pak.Objects
                     EGame.GAME_BlackMythWukong => [OffsetsToTry.SizeB1],
                     EGame.GAME_Rennsport => [OffsetsToTry.SizeRennsport],
                     EGame.GAME_RacingMaster => [OffsetsToTry.SiseRacingMaster],
+                    EGame.GAME_ARKSurvivalAscended => [OffsetsToTry.ARKSurvivalAscended],
                     _ => _offsetsToTry
                 };
                 foreach (var offset in offsetsToTry)

--- a/CUE4Parse/UE4/Versions/EGame.cs
+++ b/CUE4Parse/UE4/Versions/EGame.cs
@@ -109,6 +109,7 @@ public enum EGame
         GAME_PaxDei = GAME_UE5_2 + 2,
         GAME_TheFirstDescendant = GAME_UE5_2 + 3,
         GAME_MetroAwakening = GAME_UE5_2 + 4,
+        GAME_ARKSurvivalAscended = GAME_UE5_2 + 5,
     GAME_UE5_3 = GameUtils.GameUe5Base + 3 << 4,
         GAME_MarvelRivals = GAME_UE5_3 + 1,
         GAME_WildAssault = GAME_UE5_3 + 2,


### PR DESCRIPTION
CUE4Parse already has support for ARK: Survival Evolved. This PR adds support for ARK: Survival Ascended which requires an additional 8 byte offset for pak files. 

Closes #197 