### PR TITLE
Fix Marvel Rivals StringTables

### DIFF
--- a/CUE4Parse/UE4/Assets/Exports/Internationalization/FStringTable.cs
+++ b/CUE4Parse/UE4/Assets/Exports/Internationalization/FStringTable.cs
@@ -16,7 +16,7 @@ public class FStringTable
         TableNamespace = Ar.ReadFString();
 
         KeysToEntries = Ar.ReadMap(Ar.ReadFString, Ar.ReadFString);
-        if (Ar.Game == EGame.GAME_Wildgate) return;
+        if (Ar.Game == EGame.GAME_Wildgate || Ar.Game == EGame.GAME_MarvelRivals) return;
         KeysToMetaData = Ar.ReadMap(Ar.ReadFString, () => Ar.ReadMap(Ar.ReadFName, Ar.ReadFString));
     }
 }

--- a/CUE4Parse/UE4/Assets/Exports/Internationalization/FStringTable.cs
+++ b/CUE4Parse/UE4/Assets/Exports/Internationalization/FStringTable.cs
@@ -15,8 +15,13 @@ public class FStringTable
     {
         TableNamespace = Ar.ReadFString();
 
-        KeysToEntries = Ar.ReadMap(Ar.ReadFString, Ar.ReadFString);
-        if (Ar.Game == EGame.GAME_Wildgate || Ar.Game == EGame.GAME_MarvelRivals) return;
+        KeysToEntries = Ar.ReadMap(Ar.ReadFString, () =>
+        {
+            var value = Ar.ReadFString();
+            if (Ar.Game == EGame.GAME_MarvelRivals) Ar.Position += 4;
+            return value;
+        });
+        if (Ar.Game == EGame.GAME_Wildgate) return;
         KeysToMetaData = Ar.ReadMap(Ar.ReadFString, () => Ar.ReadMap(Ar.ReadFName, Ar.ReadFString));
     }
 }


### PR DESCRIPTION
Hacky fix to fix loading datatables in Marvel Rivals.
This leaves data unread so a proper fix is maybe necessary.

i.e.
```
[13:30:15 WRN] Did not read StringTable correctly, 85 bytes remaining (11.66%)
[13:30:15 WRN] Did not read StringTable correctly, 85 bytes remaining (11.66%)
[13:30:15 WRN] Did not read StringTable correctly, 85 bytes remaining (11.66%)
[13:30:15 WRN] Did not read StringTable correctly, 89 bytes remaining (12.21%)
[13:30:15 WRN] Did not read StringTable correctly, 89 bytes remaining (12.21%)
[13:30:15 WRN] Did not read StringTable correctly, 89 bytes remaining (12.21%)
[13:30:15 WRN] Did not read StringTable correctly, 89 bytes remaining (12.24%)
[13:30:15 WRN] Did not read StringTable correctly, 89 bytes remaining (12.24%)
[13:30:15 WRN] Did not read StringTable correctly, 89 bytes remaining (12.24%)
```