### PR TITLE
Update EGame.GAME_UE5_LATEST to be the latest version

### DIFF
--- a/CUE4Parse/UE4/Versions/EGame.cs
+++ b/CUE4Parse/UE4/Versions/EGame.cs
@@ -149,7 +149,7 @@ public enum EGame : uint
     GAME_UE5_6 = GameUtils.GameUe5Base + (6 << 16),
     GAME_UE5_7 = GameUtils.GameUe5Base + (7 << 16),
 
-    GAME_UE5_LATEST = GAME_UE5_6
+    GAME_UE5_LATEST = GAME_UE5_7
 }
 
 public static class GameUtils


### PR DESCRIPTION
I have a feeling, internally in CUE4Parse, this is intentional, but it doesn't make sense to me, it should always be the latest version.