### PR TITLE
Fix staticparameters not showing on ue versions below 4.19

### DIFF
--- a/CUE4Parse/UE4/Assets/Exports/Material/UMaterialInstance.cs
+++ b/CUE4Parse/UE4/Assets/Exports/Material/UMaterialInstance.cs
@@ -14,6 +14,7 @@ public class UMaterialInstanceDynamic: UMaterialInstance;
 public class UMaterialInstance : UMaterialInterface
 {
     private ResolvedObject? _parent;
+    private bool bHasNonUPropertyStaticParameters = false;
     public UUnrealMaterial? Parent => _parent?.Load<UUnrealMaterial>();
     public bool bHasStaticPermutationResource;
     public FMaterialInstanceBasePropertyOverrides? BasePropertyOverrides;
@@ -39,6 +40,7 @@ public class UMaterialInstance : UMaterialInterface
             if (FRenderingObjectVersion.Get(Ar) < FRenderingObjectVersion.Type.MaterialAttributeLayerParameters)
             {
                 StaticParameters = new FStaticParameterSet(Ar);
+                bHasNonUPropertyStaticParameters = true;
             }
 
             if (Ar is { Game: >= EGame.GAME_UE4_25, Owner.Provider.ReadShaderMaps: true })
@@ -84,6 +86,13 @@ public class UMaterialInstance : UMaterialInterface
         {
             writer.WritePropertyName("CachedData");
             serializer.Serialize(writer, CachedData);
+        }
+
+        //fix StaticParameters not showing in the json on versions such as 4.16
+        if (StaticParameters != null && bHasNonUPropertyStaticParameters)
+        {
+            writer.WritePropertyName("StaticParameters");
+            serializer.Serialize(writer, StaticParameters);
         }
     }
 }


### PR DESCRIPTION
below 4.19 StaticParameters is not a uproperty, this means that in UObject.WriteJson, StaticParameters won't be written during the writing of uproperties. this PR addresses this issue by writing the staticparameters if necessary in UMaterialInterface.WriteJson

note: this means that they wont be under the properties json object, so anyone wishing to parse the json will have to watch out for that.