### PR TITLE
Arc System Works animations, 2XKO script bytecode

### DIFF
--- a/CUE4Parse-Conversion/Animations/UEFormat/UEAnim.cs
+++ b/CUE4Parse-Conversion/Animations/UEFormat/UEAnim.cs
@@ -21,14 +21,14 @@ public class UEAnim : UEFormatExport
         {
             metaDataChunk.Write(sequence.NumFrames);
             metaDataChunk.Write(sequence.FramesPerSecond);
-            
+
             var referencePath = originalSequence.RefPoseSeq?.GetPathName() ?? string.Empty;
             metaDataChunk.WriteFString(referencePath);
-            
+
             metaDataChunk.Write((byte) originalSequence.AdditiveAnimType); // EAdditiveAnimationType
             metaDataChunk.Write((byte) originalSequence.RefPoseType); // EAdditiveBasePoseType
             metaDataChunk.Write(originalSequence.RefFrameIndex);
-            
+
             metaDataChunk.Serialize(Ar);
         }
 
@@ -59,23 +59,58 @@ public class UEAnim : UEFormatExport
                         track.GetBoneTransform(frame, sequence.NumFrames, ref rotation, ref translation, ref scale);
                     }
 
-                    // dupe key reduction, could be better but it works for now
-                    if (prevPos is null || prevPos != translation)
+                    if (originalSequence.GetOrDefault<bool>("bConstantAnimation"))
                     {
-                        positionKeys.Add(new FVectorKey(frame, translation));
-                        prevPos = translation;
-                    }
+                        if (prevPos is null || (prevPos != translation && track.KeyPosTime.Contains(frame)))
+                        {
+                            if (prevPos != null)
+                            {
+                                positionKeys.Add(new FVectorKey(frame - 1, (FVector)prevPos));
+                            }
+                            positionKeys.Add(new FVectorKey(frame, translation));
+                            prevPos = translation;
+                        }
 
-                    if (prevRot is null || prevRot != rotation)
-                    {
-                        rotationKeys.Add(new FQuatKey(frame, rotation));
-                        prevRot = rotation;
-                    }
+                        if (prevRot is null || (prevRot != rotation && track.KeyQuatTime.Contains(frame)))
+                        {
+                            if (prevRot != null)
+                            {
+                                rotationKeys.Add(new FQuatKey(frame - 1, (FQuat)prevRot));
+                            }
+                            rotationKeys.Add(new FQuatKey(frame, rotation));
+                            prevRot = rotation;
+                        }
 
-                    if (prevScale is null || prevScale != scale)
+                        if (prevScale is null || (prevScale != scale && track.KeyScaleTime.Contains(frame)))
+                        {
+                            if (prevScale != null)
+                            {
+                                scaleKeys.Add(new FVectorKey(frame - 1, (FVector)prevScale));
+                            }
+                            scaleKeys.Add(new FVectorKey(frame, scale));
+                            prevScale = scale;
+                        }
+                    }
+                    else
                     {
-                        scaleKeys.Add(new FVectorKey(frame, scale));
-                        prevScale = scale;
+                        // dupe key reduction, could be better but it works for now
+                        if (prevPos is null || prevPos != translation)
+                        {
+                            positionKeys.Add(new FVectorKey(frame, translation));
+                            prevPos = translation;
+                        }
+
+                        if (prevRot is null || prevRot != rotation)
+                        {
+                            rotationKeys.Add(new FQuatKey(frame, rotation));
+                            prevRot = rotation;
+                        }
+
+                        if (prevScale is null || prevScale != scale)
+                        {
+                            scaleKeys.Add(new FVectorKey(frame, scale));
+                            prevScale = scale;
+                        }
                     }
                 }
 

--- a/CUE4Parse/UE4/Assets/Readers/FKismetArchive.cs
+++ b/CUE4Parse/UE4/Assets/Readers/FKismetArchive.cs
@@ -134,6 +134,7 @@ public class FKismetArchive : FArchive
             EExprToken.EX_Placeholder1 when Versions.Game == EGame.GAME_WutheringWaves => new EX_WuWaInstr1(this),
             EExprToken.EX_Placeholder1 when Versions.Game == EGame.GAME_DeltaForceHawkOps => new EX_DFInstr(this),
             EExprToken.EX_Placeholder2 when Versions.Game == EGame.GAME_WutheringWaves => new EX_WuWaInstr2(this),
+            EExprToken.EX_FixedPointConst => new EX_FixedPointConst(this),
             _ => throw new ParserException($"Unknown EExprToken {token}")
         };
         expression.StatementIndex = index;

--- a/CUE4Parse/UE4/Kismet/EExprToken.cs
+++ b/CUE4Parse/UE4/Kismet/EExprToken.cs
@@ -118,6 +118,7 @@ public enum EExprToken : byte
     EX_AutoRtfmTransact     = 0x70, // AutoRTFM: run following code in a transaction
     EX_AutoRtfmStopTransact = 0x71, // AutoRTFM: if in a transaction, abort or break, otherwise no operation
     EX_AutoRtfmAbortIfNot   = 0x72, // AutoRTFM: evaluate bool condition, abort transaction on false
+    EX_FixedPointConst		= 0xFD,
     EX_Max					= 0xFF,
 };
 

--- a/CUE4Parse/UE4/Kismet/KismetExpression.cs
+++ b/CUE4Parse/UE4/Kismet/KismetExpression.cs
@@ -1342,6 +1342,16 @@ public class EX_UInt64Const : KismetExpression<ulong>
     }
 }
 
+public class EX_FixedPointConst : KismetExpression<long>
+{
+    public override EExprToken Token => EExprToken.EX_FixedPointConst;
+
+    public EX_FixedPointConst(FKismetArchive Ar)
+    {
+        Value = Ar.Read<long>();
+    }
+}
+
 public class EX_UnicodeStringConst : KismetExpression<string>
 {
     public override EExprToken Token => EExprToken.EX_UnicodeStringConst;

--- a/CUE4Parse/UE4/Objects/UObject/BlueprintDecompiler/BlueprintDecompilerUtils.cs
+++ b/CUE4Parse/UE4/Objects/UObject/BlueprintDecompiler/BlueprintDecompilerUtils.cs
@@ -1332,6 +1332,10 @@ public static class BlueprintDecompilerUtils
             {
                 return propertyConst.Property.ToString();
             }
+            case EX_FixedPointConst fp:
+            {
+                return fp.Value.ToString();
+            }
 
             // good enough?
             case EX_WireTracepoint:


### PR DESCRIPTION
Changelog:

- Animations using AnimCompress_Constant (Arc System Works custom compression) will export properly.
- 2XKO has a custom script bytecode instruction for fixed-point integers. As the instruction ID doesn't overlap with any other games (0xFD), I did not make a custom game configuration. If needed, please change.