### PR TITLE
Remove WriteJson for FeatureLevelSwitch/QualitySwitch, Write to Inputs array properly

### DIFF
--- a/CUE4Parse/UE4/Assets/Exports/Material/UMaterialExpressionFeatureLevelSwitch.cs
+++ b/CUE4Parse/UE4/Assets/Exports/Material/UMaterialExpressionFeatureLevelSwitch.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-using CUE4Parse.UE4.Assets.Objects;
 using CUE4Parse.UE4.Assets.Readers;
 using CUE4Parse.UE4.Objects.Engine;
 
@@ -7,34 +5,14 @@ namespace CUE4Parse.UE4.Assets.Exports.Material;
 
 public class UMaterialExpressionFeatureLevelSwitch : UMaterialExpression
 {
-    public List<FExpressionInput> Inputs = new((int) ERHIFeatureLevel.Num);
-
-    public UMaterialExpressionFeatureLevelSwitch()
-    {
-        for (int i = 0; i < (int) ERHIFeatureLevel.Num; i++)
-        {
-            Inputs.Add(null!);
-        }
-    }
+    public FExpressionInput[] Inputs = [];
 
     public override void Deserialize(FAssetArchive Ar, long validPos)
     {
         base.Deserialize(Ar, validPos);
-
-        foreach (var property in Properties)
+        if (!TryGetAllValues(out Inputs, nameof(Inputs)))
         {
-            if (property.Name.Text != "Inputs") continue;
-            if (property.Tag?.GenericValue is not FScriptStruct { StructType: FExpressionInput input }) continue;
-
-            var index = property.ArrayIndex;
-            if (index < 0) continue;
-
-            if (index >= Inputs.Count)
-            {
-                Inputs.AddRange(new FExpressionInput?[index - Inputs.Count + 1]!);
-            }
-
-            Inputs[index] = input;
+            Inputs = new FExpressionInput[(int) ERHIFeatureLevel.Num];
         }
     }
 }

--- a/CUE4Parse/UE4/Assets/Exports/Material/UMaterialExpressionQualitySwitch.cs
+++ b/CUE4Parse/UE4/Assets/Exports/Material/UMaterialExpressionQualitySwitch.cs
@@ -1,41 +1,18 @@
-using System.Collections.Generic;
-using CUE4Parse.UE4.Assets.Objects;
 using CUE4Parse.UE4.Assets.Readers;
 using CUE4Parse.UE4.Objects.Engine;
-using Newtonsoft.Json;
 
 namespace CUE4Parse.UE4.Assets.Exports.Material;
 
 public class UMaterialExpressionQualitySwitch : UMaterialExpression
 {
-    public List<FExpressionInput> Inputs = new((int) EMaterialQualityLevel.Num);
-
-    public UMaterialExpressionQualitySwitch()
-    {
-        for (int i = 0; i < (int) EMaterialQualityLevel.Num; i++)
-        {
-            Inputs.Add(null!);
-        }
-    }
+    public FExpressionInput[] Inputs = [];
 
     public override void Deserialize(FAssetArchive Ar, long validPos)
     {
         base.Deserialize(Ar, validPos);
-
-        foreach (var property in Properties)
+        if (!TryGetAllValues(out Inputs, nameof(Inputs)))
         {
-            if (property.Name.Text != "Inputs") continue;
-            if (property.Tag?.GenericValue is not FScriptStruct { StructType: FExpressionInput input }) continue;
-
-            var index = property.ArrayIndex;
-            if (index < 0) continue;
-
-            if (index >= Inputs.Count)
-            {
-                Inputs.AddRange(new FExpressionInput?[index - Inputs.Count + 1]!);
-            }
-
-            Inputs[index] = input;
+            Inputs = new FExpressionInput[(int) EMaterialQualityLevel.Num];
         }
     }
 }


### PR DESCRIPTION
The WriteJson function served to create more issues for interpreting the data, and since static arrays are already parsed into Property[Index], this is no longer needed.

Issue: Ambiguous Input Index (if the last input is used in the original data, it's put as the first index of the array)
Solution: Use FPropertyTag.ArrayIndex, and write to the Inputs array