### PR TITLE
Keep original Properties, remove forced clear [UCurveLinearColor, UCurveVector]

### DIFF
--- a/CUE4Parse/UE4/Objects/Engine/Curves/UCurveLinearColor.cs
+++ b/CUE4Parse/UE4/Objects/Engine/Curves/UCurveLinearColor.cs
@@ -31,8 +31,6 @@ namespace CUE4Parse.UE4.Objects.Engine.Curves
                     FloatCurves[i] = new FRichCurve(fallback);
                 }
             }
-
-            if (FloatCurves.Length > 0) Properties.Clear(); // Don't write these for this object
         }
 
         protected internal override void WriteJson(JsonWriter writer, JsonSerializer serializer)

--- a/CUE4Parse/UE4/Objects/Engine/Curves/UCurveVector.cs
+++ b/CUE4Parse/UE4/Objects/Engine/Curves/UCurveVector.cs
@@ -22,8 +22,6 @@ namespace CUE4Parse.UE4.Objects.Engine.Curves
                     FloatCurves[i] = new FRichCurve(fallback);
                 }
             }
-
-            if (FloatCurves.Length > 0) Properties.Clear(); // Don't write these for this object
         }
 
         protected internal override void WriteJson(JsonWriter writer, JsonSerializer serializer)


### PR DESCRIPTION
- Allows tools to use standard property deserialization
- Simplifies downstream handling of StructProperty based curves