### PR TITLE
Include System.IO so SearchOption is not missing

### DIFF
--- a/CUE4Parse.Example/Program.cs
+++ b/CUE4Parse.Example/Program.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using CUE4Parse.Encryption.Aes;
 using CUE4Parse.FileProvider;
 using CUE4Parse.UE4.Objects.Core.Misc;


### PR DESCRIPTION
When you uncomment the part with ``SearchOption.TopDirectoryOnly``, you'd be missing ``System.IO`` for ``SearchOption``