### PR TITLE
Fix inverted ternary operator in BP decompiler

### DIFF
--- a/CUE4Parse/UE4/Objects/UObject/BlueprintDecompiler/BlueprintDecompilerUtils.cs
+++ b/CUE4Parse/UE4/Objects/UObject/BlueprintDecompiler/BlueprintDecompilerUtils.cs
@@ -1315,10 +1315,10 @@ public static class BlueprintDecompilerUtils
                 {
                     var indexTerm = GetLineExpression(switchValue.IndexTerm);
 
-                    var case1 = GetLineExpression(switchValue.Cases[0].CaseTerm);
-                    var case2 = GetLineExpression(switchValue.Cases[1].CaseTerm);
+                    var case0 = GetLineExpression(switchValue.Cases[0].CaseTerm);
+                    var case1 = GetLineExpression(switchValue.Cases[1].CaseTerm);
 
-                    return $"{indexTerm} ? {case1} : {case2}";
+                    return $"{indexTerm} ? {case1} : {case0}";
                 }
 
                 var stringBuilder = new CustomStringBuilder();


### PR DESCRIPTION
For an example of where this is an issue, see AthenaTeamMemberDBNOState_C::Set DBNO:39 in Fortnite 1.7.2-CL-3700114