### PR TITLE
Always read CellOffsets when Ver >= VERSE_CELLS

### DIFF
--- a/CUE4Parse/UE4/Assets/IoPackage.cs
+++ b/CUE4Parse/UE4/Assets/IoPackage.cs
@@ -95,7 +95,7 @@ namespace CUE4Parse.UE4.Assets
                 }
 
                 FZenPackageCellOffsets cellOffsets;
-                if (summary.bHasVersioningInfo == 0 && uassetAr.Ver >= EUnrealEngineObjectUE5Version.VERSE_CELLS)
+                if (uassetAr.Ver >= EUnrealEngineObjectUE5Version.VERSE_CELLS)
                 {
                     cellOffsets = uassetAr.Read<FZenPackageCellOffsets>();
                 }


### PR DESCRIPTION
The current check does not read cell offsets for versioned UE 5.6 assets, which causes parsing to fail for Grounded 2 assets (after that game upgraded to UE 5.6 with its 0.2 update).