### PR TITLE
Update AdxDecoder.cs

### DIFF
--- a/CUE4Parse/UE4/CriWare/Decoders/ADX/AdxDecoder.cs
+++ b/CUE4Parse/UE4/CriWare/Decoders/ADX/AdxDecoder.cs
@@ -1,41 +1,156 @@
 using System;
 using System.IO;
-using VGAudio.Codecs.CriAdx;
 using VGAudio.Containers.Adx;
 using VGAudio.Containers.Wave;
-using VGAudio.Formats;
 
 namespace CUE4Parse.UE4.CriWare.Decoders.ADX;
 
 public static class AdxDecoder
 {
-    public static byte[] ConvertAdxToWav(byte[] adxDataWithSubkey, ulong key)
+    private static readonly byte[][] ADX_SIGNATURES =
     {
-        if (adxDataWithSubkey == null || adxDataWithSubkey.Length <= sizeof(ushort))
-            throw new ArgumentException("Invalid HCA data.");
+        new byte[] { 0x03, 0x12, 0x04, 0x01, 0x00, 0x00 },
+        new byte[] { 0x03, 0x12, 0x04, 0x02, 0x00, 0x00 }
+    };
 
-        var (subKey, adxData) = adxDataWithSubkey.ExtractSubKey();
+    private static readonly byte[] CRI_COPYRIGHT = { 0x28, 0x63, 0x29, 0x43, 0x52, 0x49 }; // "(c)CRI"
 
-        if (subKey != 0 && key == 0) // Not sure if this is correct way to detect encryption on ADX
-            throw new CriwareDecryptionException("CRIWARE audio is encrypted. Provide the correct decryption key in settings (numeric or hexadecimal format, up to 20 digits / 8 bytes).");
-
-        if (subKey != 0)
+    public static byte[] ConvertAdxToWav(byte[] rawData, ulong key)
+    {
+        try
         {
-            key *= (((ulong) subKey << 16) | ((ushort) (~subKey + 2)));
+            Console.WriteLine($"[ADX Decode] Original data length: {rawData?.Length}");
+
+            byte[] extractedAdx = ExtractAdxFromMemory(rawData);
+            if (extractedAdx == null || extractedAdx.Length == 0)
+            {
+                Console.WriteLine("[ADX Decode] Error: Unable to extract ADX from file");
+                throw new InvalidDataException("No valid ADX data found");
+            }
+            Console.WriteLine($"[ADX Decode] Extracted ADX data length: {extractedAdx.Length}");
+            
+            // Debug output: first 64 bytes
+            for (int i = 0; i < Math.Min(64, extractedAdx.Length); i++)
+            {
+                if (i % 16 == 0) Console.Write("\n");
+                Console.Write($"{extractedAdx[i]:X2} ");
+            }
+            Console.WriteLine();
+
+            return DecodeAdxToWav(extractedAdx);
         }
-
-        var reader = new AdxReader
+        catch (Exception ex)
         {
-            EncryptionKey = new CriAdxKey(key)
-        };
+            Console.WriteLine($"[ADX Decode Error] {ex.Message}");
+            throw;
+        }
+    }
 
-        var audioWithConfig = reader.ReadWithConfig(adxData);
-        AudioData audioData = audioWithConfig.Audio;
+    private static byte[] ExtractAdxFromMemory(byte[] data)
+    {
+        if (data == null || data.Length < 0x20)
+            return null;
 
-        using var stream = new MemoryStream();
-        var writer = new WaveWriter();
-        writer.WriteToStream(audioData, stream, null);
+        for (int i = 0; i <= data.Length - 0x20; i++)
+        {
+            // Look for ADX signature: 0x80 0x00
+            if (data[i] == 0x80 && data[i + 1] == 0x00)
+            {
+                bool hasValidSignature = false;
+                
+                // Check the 6-byte sequence at offset 4
+                foreach (var signature in ADX_SIGNATURES)
+                {
+                    bool match = true;
+                    for (int j = 0; j < 6; j++)
+                    {
+                        if (i + 4 + j >= data.Length || data[i + 4 + j] != signature[j])
+                        {
+                            match = false;
+                            break;
+                        }
+                    }
+                    if (match)
+                    {
+                        hasValidSignature = true;
+                        Console.WriteLine($"[ADX Extract] Found valid ADX signature at position {i}");
+                        break;
+                    }
+                }
 
-        return stream.ToArray();
+                if (!hasValidSignature)
+                    continue;
+
+                // Search for copyright information "(c)CRI"
+                bool hasCopyright = false;
+                int copyrightSearchStart = i + 0x14;
+                int copyrightSearchEnd = Math.Min(i + 0x1000, data.Length - 6);
+
+                for (int j = copyrightSearchStart; j <= copyrightSearchEnd; j++)
+                {
+                    bool match = true;
+                    for (int k = 0; k < 6; k++)
+                    {
+                        if (j + k >= data.Length || data[j + k] != CRI_COPYRIGHT[k])
+                        {
+                            match = false;
+                            break;
+                        }
+                    }
+
+                    if (match)
+                    {
+                        hasCopyright = true;
+                        Console.WriteLine($"[ADX Extract] Found copyright information at position {j}");
+                        break;
+                    }
+                }
+
+                if (!hasCopyright)
+                {
+                    Console.WriteLine($"[ADX Extract] Found ADX signature at position {i} but no copyright information");
+                    continue;
+                }
+
+                Console.WriteLine($"[ADX Extract] Found valid ADX, removing first {i} bytes");
+
+                // Extract ADX data from current position to end
+                int adxLength = data.Length - i;
+                byte[] adxData = new byte[adxLength];
+                Buffer.BlockCopy(data, i, adxData, 0, adxLength);
+
+                return adxData;
+            }
+        }
+        
+        Console.WriteLine("[ADX Extract] No valid ADX data found");
+        return null;
+    }
+
+    private static byte[] DecodeAdxToWav(byte[] adxData)
+    {
+        try
+        {
+            Console.WriteLine("[ADX Decode] Using VGAudio to decode...");
+
+            var reader = new AdxReader();
+            var audioWithConfig = reader.ReadWithConfig(adxData);
+
+            if (audioWithConfig?.Audio == null)
+                throw new InvalidOperationException("VGAudio returned null audio data");
+
+            using var stream = new MemoryStream();
+            var writer = new WaveWriter();
+            writer.WriteToStream(audioWithConfig.Audio, stream, null);
+
+            byte[] wavData = stream.ToArray();
+            Console.WriteLine($"[ADX Decode] Success, WAV size: {wavData.Length}");
+            return wavData;
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"[ADX Decode] Decoding failed: {ex.Message}");
+            throw;
+        }
     }
 }


### PR DESCRIPTION
Fix the issue where ADX files in uasset cannot be played。

I was very happy when I discovered that Fmodel supports Criware audio. However, I found that HCA files in Unreal Engine games could play and convert normally, while ADX files could only be converted but not played. This made me very puzzled, as the extracted ADX files were clearly normal. Why couldn't they be played? With this question in mind, I found AdxDecoder.cs. It uses the VGAudio library. I downloaded the VGAudio command-line tool to decode ADX and tested it, and indeed it could convert to WAV. So the problem isn't with the VGAudio library, but with the AdxDecoder.cs code being faulty.

Both HCA and ADX audio are packaged into files like uasset and uexp. I suspected that AdxDecoder.cs wasn't correctly handling ADX files in uassets, as the ADX files might be prefixed with garbage bytes. As long as those garbage bytes are removed, they should play. I tested this and succeeded. Now Fmodel can normally play uassets containing ADX.

In the current version of Fmodel, because ADX cannot be decoded to WAV, the audio player shows the file with an ADX extension in the playlist, and saves it as ADX format in the output directory. After my fix, the playlist shows WAV extensions, and the output directory also saves WAV files. 