### PR TITLE
allow reading package data from a given FByteBulkData header

### DIFF
--- a/CUE4Parse.Tests/Shared.cs
+++ b/CUE4Parse.Tests/Shared.cs
@@ -1,6 +1,7 @@
 ﻿using CUE4Parse.Compression;
 using CUE4Parse.FileProvider;
 using CUE4Parse.FileProvider.Objects;
+using CUE4Parse.UE4.Assets.Objects;
 using CUE4Parse.UE4.Readers;
 
 namespace CUE4Parse.Tests;
@@ -10,8 +11,8 @@ public class DummyGameFile : GameFile
     public override bool IsEncrypted => false;
     public override CompressionMethod CompressionMethod => CompressionMethod.None;
 
-    public override byte[] Read() => throw new NotImplementedException();
-    public override FArchive CreateReader() => throw new NotImplementedException();
+    public override byte[] Read(FByteBulkDataHeader? header = null) => throw new NotImplementedException();
+    public override FArchive CreateReader(FByteBulkDataHeader? header = null) => throw new NotImplementedException();
 }
 
 public class DummyFileProvider : AbstractFileProvider

--- a/CUE4Parse/FileProvider/AbstractFileProvider.cs
+++ b/CUE4Parse/FileProvider/AbstractFileProvider.cs
@@ -14,6 +14,7 @@ using CUE4Parse.MappingsProvider;
 using CUE4Parse.UE4.Assets;
 using CUE4Parse.UE4.Assets.Exports;
 using CUE4Parse.UE4.Assets.Exports.Internationalization;
+using CUE4Parse.UE4.Assets.Objects;
 using CUE4Parse.UE4.IO.Objects;
 using CUE4Parse.UE4.Objects.Core.Misc;
 using CUE4Parse.UE4.Objects.Engine;
@@ -576,8 +577,8 @@ namespace CUE4Parse.FileProvider
             Files.FindPayloads(file, out var uexp, out var ubulks, out var uptnls);
 
             var uasset = file.CreateReader();
-            var lazyUbulk = ubulks.Count > 0 ? new Lazy<FArchive?>(() => ubulks[0].SafeCreateReader()) : null;
-            var lazyUptnl = uptnls.Count > 0 ? new Lazy<FArchive?>(() => uptnls[0].SafeCreateReader()) : null;
+            var lazyUbulk = ubulks.Count > 0 ? new Func<FByteBulkDataHeader?, FArchive?>(header => ubulks[0].SafeCreateReader(header)) : null;
+            var lazyUptnl = uptnls.Count > 0 ? new Func<FByteBulkDataHeader?, FArchive?>(header => uptnls[0].SafeCreateReader(header)) : null;
 
             switch (file)
             {
@@ -598,8 +599,8 @@ namespace CUE4Parse.FileProvider
             Files.FindPayloads(file, out var uexp, out var ubulks, out var uptnls);
 
             var uasset = await file.CreateReaderAsync().ConfigureAwait(false);
-            var lazyUbulk = ubulks.Count > 0 ? new Lazy<FArchive?>(() => ubulks[0].SafeCreateReader()) : null;
-            var lazyUptnl = uptnls.Count > 0 ? new Lazy<FArchive?>(() => uptnls[0].SafeCreateReader()) : null;
+            var lazyUbulk = ubulks.Count > 0 ? new Func<FByteBulkDataHeader?, FArchive?>(header => ubulks[0].SafeCreateReader(header)) : null;
+            var lazyUptnl = uptnls.Count > 0 ? new Func<FByteBulkDataHeader?, FArchive?>(header => uptnls[0].SafeCreateReader(header)) : null;
 
             switch (file)
             {

--- a/CUE4Parse/FileProvider/Objects/GameFile.cs
+++ b/CUE4Parse/FileProvider/Objects/GameFile.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using CUE4Parse.Compression;
+using CUE4Parse.UE4.Assets.Objects;
 using CUE4Parse.UE4.Readers;
 using CUE4Parse.Utils;
 using Serilog;
@@ -71,15 +72,15 @@ public abstract class GameFile
     public bool IsUePackage => UePackageExtensionsSet.Contains(Extension);
     public bool IsUePackagePayload => UePackagePayloadExtensionsSet.Contains(Extension);
 
-    public abstract byte[] Read();
-    public abstract FArchive CreateReader();
+    public abstract byte[] Read(FByteBulkDataHeader? header = null);
+    public abstract FArchive CreateReader(FByteBulkDataHeader? header = null);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public bool TryRead([MaybeNullWhen(false)] out byte[] data)
+    public bool TryRead([MaybeNullWhen(false)] out byte[] data, FByteBulkDataHeader? header = null)
     {
         try
         {
-            data = Read();
+            data = Read(header);
         }
         catch (Exception e)
         {
@@ -90,11 +91,11 @@ public abstract class GameFile
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public bool TryCreateReader([MaybeNullWhen(false)] out FArchive reader)
+    public bool TryCreateReader([MaybeNullWhen(false)] out FArchive reader, FByteBulkDataHeader? header = null)
     {
         try
         {
-            reader = CreateReader();
+            reader = CreateReader(header);
         }
         catch (Exception e)
         {
@@ -105,46 +106,46 @@ public abstract class GameFile
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public byte[]? SafeRead()
+    public byte[]? SafeRead(FByteBulkDataHeader? header = null)
     {
-        TryRead(out var data);
+        TryRead(out var data, header);
         return data;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public FArchive? SafeCreateReader()
+    public FArchive? SafeCreateReader(FByteBulkDataHeader? header = null)
     {
-        TryCreateReader(out var reader);
+        TryCreateReader(out var reader, header);
         return reader;
     }
 
     // No ConfigureAwait(false) here since the context is needed handling exceptions
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public async Task<byte[]> ReadAsync() => await Task.Run(Read);
+    public async Task<byte[]> ReadAsync() => await Task.Run(() => Read());
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public async Task<FArchive> CreateReaderAsync() => await Task.Run(CreateReader);
+    public async Task<FArchive> CreateReaderAsync() => await Task.Run(() => CreateReader());
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public async Task<byte[]?> SafeReadAsync() => await Task.Run(SafeRead);
+    public async Task<byte[]?> SafeReadAsync() => await Task.Run(() => SafeRead());
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public async Task<FArchive?> SafeCreateReaderAsync() => await Task.Run(SafeCreateReader);
+    public async Task<FArchive?> SafeCreateReaderAsync() => await Task.Run(() => SafeCreateReader());
 
     public override string ToString() => Path;
-    
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static string InternExtension(string extension)
     {
         if (InternedExtensions.TryGetValue(extension, out var interned))
             return interned;
-        
+
         lock (InternedExtensions)
         {
             if (InternedExtensions.TryGetValue(extension, out interned))
                 return interned;
-            
+
             InternedExtensions[extension] = extension;
             return extension;
         }

--- a/CUE4Parse/FileProvider/Objects/GameFile.cs
+++ b/CUE4Parse/FileProvider/Objects/GameFile.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
@@ -28,7 +29,7 @@ public abstract class GameFile
     public static readonly HashSet<string> UeKnownExtensionsSet = UeKnownExtensions.ToHashSet(StringComparer.OrdinalIgnoreCase);
 
     // so we don't end up with a lot of duplicate "uasset"s in memory
-    private static readonly Dictionary<string, string> InternedExtensions = new(StringComparer.OrdinalIgnoreCase);
+    private static readonly ConcurrentDictionary<string, string> _internedExtensions = new(StringComparer.OrdinalIgnoreCase);
 
     private string _path;
     private string? _directory;
@@ -138,16 +139,10 @@ public abstract class GameFile
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static string InternExtension(string extension)
     {
-        if (InternedExtensions.TryGetValue(extension, out var interned))
+        if (_internedExtensions.TryGetValue(extension, out var interned))
             return interned;
 
-        lock (InternedExtensions)
-        {
-            if (InternedExtensions.TryGetValue(extension, out interned))
-                return interned;
-
-            InternedExtensions[extension] = extension;
-            return extension;
-        }
+        _internedExtensions[extension] = extension;
+        return extension;
     }
 }

--- a/CUE4Parse/FileProvider/Objects/OsGameFile.cs
+++ b/CUE4Parse/FileProvider/Objects/OsGameFile.cs
@@ -1,6 +1,7 @@
 ﻿using System.IO;
 using System.Runtime.CompilerServices;
 using CUE4Parse.Compression;
+using CUE4Parse.UE4.Assets.Objects;
 using CUE4Parse.UE4.Versions;
 
 namespace CUE4Parse.FileProvider.Objects
@@ -19,6 +20,6 @@ namespace CUE4Parse.FileProvider.Objects
         public override CompressionMethod CompressionMethod => CompressionMethod.None;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public override byte[] Read() => File.ReadAllBytes(ActualFile.FullName);
+        public override byte[] Read(FByteBulkDataHeader? header = null) => File.ReadAllBytes(ActualFile.FullName);
     }
 }

--- a/CUE4Parse/FileProvider/Objects/StreamedGameFile.cs
+++ b/CUE4Parse/FileProvider/Objects/StreamedGameFile.cs
@@ -1,6 +1,7 @@
 ﻿using System.IO;
 
 using CUE4Parse.Compression;
+using CUE4Parse.UE4.Assets.Objects;
 using CUE4Parse.UE4.Versions;
 
 namespace CUE4Parse.FileProvider.Objects
@@ -19,7 +20,7 @@ namespace CUE4Parse.FileProvider.Objects
         public override bool IsEncrypted => false;
         public override CompressionMethod CompressionMethod => CompressionMethod.None;
 
-        public override byte[] Read()
+        public override byte[] Read(FByteBulkDataHeader? header = null)
         {
             var data = new byte[Size];
             var _ = _baseStream.Seek(_position, SeekOrigin.Begin);

--- a/CUE4Parse/FileProvider/Objects/VersionedGameFile.cs
+++ b/CUE4Parse/FileProvider/Objects/VersionedGameFile.cs
@@ -1,4 +1,5 @@
 ﻿using System.Runtime.CompilerServices;
+using CUE4Parse.UE4.Assets.Objects;
 using CUE4Parse.UE4.Readers;
 using CUE4Parse.UE4.Versions;
 
@@ -14,6 +15,6 @@ namespace CUE4Parse.FileProvider.Objects
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public override FArchive CreateReader() => new FByteArchive(Path, Read(), Versions);
+        public override FArchive CreateReader(FByteBulkDataHeader? header = null) => new FByteArchive(Path, Read(header), Versions);
     }
 }

--- a/CUE4Parse/FileProvider/Objects/VfcGameFile.cs
+++ b/CUE4Parse/FileProvider/Objects/VfcGameFile.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Runtime.CompilerServices;
 using CUE4Parse.Compression;
+using CUE4Parse.UE4.Assets.Objects;
 using CUE4Parse.UE4.Versions;
 using CUE4Parse.UE4.VirtualFileCache;
 
@@ -27,7 +28,7 @@ namespace CUE4Parse.FileProvider.Objects
         public override CompressionMethod CompressionMethod => CompressionMethod.None;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public override byte[] Read()
+        public override byte[] Read(FByteBulkDataHeader? header = null)
         {
             var offset = 0;
             var data = new byte[Size];

--- a/CUE4Parse/GameTypes/AshEchoes/FileProvider/AshEchoesDefaultFileProvider.cs
+++ b/CUE4Parse/GameTypes/AshEchoes/FileProvider/AshEchoesDefaultFileProvider.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using CUE4Parse.Compression;
 using CUE4Parse.FileProvider;
 using CUE4Parse.FileProvider.Objects;
+using CUE4Parse.UE4.Assets.Objects;
 using CUE4Parse.UE4.Objects.Core.Misc;
 using CUE4Parse.UE4.Pak.Objects;
 using CUE4Parse.UE4.Readers;
@@ -199,10 +200,10 @@ public class FAEPakEntry : FPakEntry
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public override byte[] Read() => Vfs.Extract(this);
+    public override byte[] Read(FByteBulkDataHeader? header = null) => Vfs.Extract(this, header);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public override FArchive CreateReader() => new FByteArchive(Path, Read(), Vfs.Versions);
+    public override FArchive CreateReader(FByteBulkDataHeader? header = null) => new FByteArchive(Path, Read(header), Vfs.Versions);
 }
 
 public class AEPakFileReader : AbstractAesVfsReader
@@ -246,7 +247,7 @@ public class AEPakFileReader : AbstractAesVfsReader
             var indexHash = Ar.Read<uint>();
             var indexData = Ar.ReadArray<byte>((int)indexLength);
             using var indexAr = new GenericBufferReader(indexData);
-            
+
             var entries = new List<FAssetEntry>(4);
             while (indexAr.Position < indexLength)
             {
@@ -287,7 +288,7 @@ public class AEPakFileReader : AbstractAesVfsReader
         }
     }
 
-    public override byte[] Extract(VfsEntry entry)
+    public override byte[] Extract(VfsEntry entry, FByteBulkDataHeader? header = null)
     {
         if (entry is not FAEPakEntry pakEntry || entry.Vfs != this) throw new ArgumentException($"Wrong pak file reader, required {entry.Vfs.Name}, this is {Name}");
         // If this reader is used as a concurrent reader create a clone of the main reader to provide thread safety

--- a/CUE4Parse/GameTypes/CrystalOfAtlan/Pak/CoAPakFileReader.cs
+++ b/CUE4Parse/GameTypes/CrystalOfAtlan/Pak/CoAPakFileReader.cs
@@ -185,7 +185,7 @@ public partial class PakFileReader
                 };
 
                 reader.Seek(0, SeekOrigin.Begin);
-                var package = new Package(reader, null, new Lazy<FArchive?>());
+                var package = new Package(reader, null, _ => null);
 
                 var exports = package.ExportMap.Where(export => export.IsAsset).ToList();
                 FObjectExport? mainExport;

--- a/CUE4Parse/UE4/Assets/IoPackage.cs
+++ b/CUE4Parse/UE4/Assets/IoPackage.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using CUE4Parse.FileProvider.Vfs;
 using CUE4Parse.UE4.Assets.Exports;
+using CUE4Parse.UE4.Assets.Objects;
 using CUE4Parse.UE4.Assets.Readers;
 using CUE4Parse.UE4.Assets.Utils;
 using CUE4Parse.UE4.Exceptions;
@@ -38,16 +39,16 @@ namespace CUE4Parse.UE4.Assets
             : this(
                 uasset,
                 containerHeader,
-                ubulk != null ? new Lazy<FArchive?>(() => ubulk) : null,
-                uptnl != null ? new Lazy<FArchive?>(() => uptnl) : null,
+                ubulk != null ? _ => ubulk : null,
+                uptnl != null ? _ => uptnl : null,
                 provider)
         { }
 
         public IoPackage(
             FArchive uasset,
             FIoContainerHeader? containerHeader = null,
-            Lazy<FArchive?>? ubulk = null,
-            Lazy<FArchive?>? uptnl = null,
+            Func<FByteBulkDataHeader?, FArchive?>? ubulk = null,
+            Func<FByteBulkDataHeader?, FArchive?>? uptnl = null,
             IVfsFileProvider? provider = null)
             : base(uasset.Name.SubstringBeforeLast('.'), provider)
         {

--- a/CUE4Parse/UE4/Assets/Objects/FByteBulkData.cs
+++ b/CUE4Parse/UE4/Assets/Objects/FByteBulkData.cs
@@ -89,65 +89,52 @@ public class FByteBulkData
         }
     }
 
-    private void CheckReadSize(int read)
-    {
-        if (read != Header.ElementCount) {
-            Log.Warning("Read {read} bytes, expected {Header.ElementCount}", read, Header.ElementCount);
-        }
-    }
-
     private bool ReadBulkDataInto(byte[] data, int offset = 0)
     {
-        if (data.Length - offset < Header.ElementCount) {
+        if (data.Length - offset < Header.ElementCount)
+        {
             Log.Error("Data buffer is too small");
             return false;
         }
 
-        var Ar = (FAssetArchive)_savedAr.Clone(); // TODO: remove and use FArchive.ReadAt
-        Ar.Position = _dataPosition;
+        var archive = _savedAr;
+        var position = _dataPosition;
+
         if (BulkDataFlags.HasFlag(BULKDATA_ForceInlinePayload))
         {
 #if DEBUG
             Log.Debug("bulk data in .uexp file (Force Inline Payload) (flags={BulkDataFlags}, pos={HeaderOffsetInFile}, size={HeaderSizeOnDisk}))", BulkDataFlags, Header.OffsetInFile, Header.SizeOnDisk);
 #endif
-            CheckReadSize(Ar.Read(data, offset, Header.ElementCount));
         }
         else if (BulkDataFlags.HasFlag(BULKDATA_OptionalPayload))
         {
 #if DEBUG
             Log.Debug("bulk data in {CookedIndex}.uptnl file (Optional Payload) (flags={BulkDataFlags}, pos={HeaderOffsetInFile}, size={HeaderSizeOnDisk}))", Header.CookedIndex, BulkDataFlags, Header.OffsetInFile, Header.SizeOnDisk);
 #endif
-            if (!TryGetBulkPayload(Ar, PayloadType.UPTNL, out var uptnlAr)) return false;
+            if (!TryGetBulkPayload(archive, PayloadType.UPTNL, out var uptnlAr))
+                return false;
 
-            CheckReadSize(Header.NeedsSeeking
-                ? uptnlAr.ReadAt(Header.OffsetInFile, data, offset, Header.ElementCount)
-                : uptnlAr.Read(data, offset, Header.ElementCount));
+            archive = uptnlAr;
+            position = uptnlAr.Length == Header.ElementCount ? 0 : Header.OffsetInFile;
         }
         else if (BulkDataFlags.HasFlag(BULKDATA_PayloadInSeperateFile))
         {
 #if DEBUG
             Log.Debug("bulk data in {CookedIndex}.ubulk file (Payload In Separate File) (flags={BulkDataFlags}, pos={HeaderOffsetInFile}, size={HeaderSizeOnDisk}))", Header.CookedIndex, BulkDataFlags, Header.OffsetInFile, Header.SizeOnDisk);
 #endif
-            if (!TryGetBulkPayload(Ar, PayloadType.UBULK, out var ubulkAr)) return false;
+            if (!TryGetBulkPayload(archive, PayloadType.UBULK, out var ubulkAr))
+                return false;
+
+            archive = ubulkAr;
+            position = ubulkAr.Length == Header.ElementCount ? 0 : Header.OffsetInFile;
+
             if (BulkDataFlags.HasFlag(BULKDATA_SerializeCompressedZLIB))
             {
                 var compressedData = new byte[Header.SizeOnDisk];
-                if (Header.NeedsSeeking)
-                {
-                    ubulkAr.ReadAt(Header.OffsetInFile, compressedData, offset, compressedData.Length);
-                }
-                else
-                {
-                    ubulkAr.ReadExactly(compressedData, offset, compressedData.Length);
-                }
-                using var dataAr = new FByteArchive("", compressedData, Ar.Versions);
-                dataAr.SerializeCompressedNew(data, GetDataSize(), "Zlib", ECompressionFlags.COMPRESS_NoFlags, false, out var decompressedLength);
-            }
-            else
-            {
-                CheckReadSize(Header.NeedsSeeking
-                    ? ubulkAr.ReadAt(Header.OffsetInFile, data, offset, Header.ElementCount)
-                    : ubulkAr.Read(data, offset, Header.ElementCount));
+                ubulkAr.ReadAt(position, compressedData, offset, compressedData.Length);
+                using var dataAr = new FByteArchive("", compressedData, _savedAr.Versions);
+                dataAr.SerializeCompressedNew(data, GetDataSize(), "Zlib", ECompressionFlags.COMPRESS_NoFlags, false, out _);
+                return true;
             }
         }
         else if (BulkDataFlags.HasFlag(BULKDATA_PayloadAtEndOfFile))
@@ -155,24 +142,28 @@ public class FByteBulkData
 #if DEBUG
             Log.Debug("bulk data in .uexp file (Payload At End Of File) (flags={BulkDataFlags}, pos={HeaderOffsetInFile}, size={HeaderSizeOnDisk}))", BulkDataFlags, Header.OffsetInFile, Header.SizeOnDisk);
 #endif
+            if (Header.OffsetInFile + Header.ElementCount > archive.Length)
+                throw new ParserException(archive, $"Failed to read PayloadAtEndOfFile, {Header.OffsetInFile} is out of range");
+
             // stored in same file, but at different position
             // save archive position
-            if (Header.OffsetInFile + Header.ElementCount <= Ar.Length)
-            {
-                CheckReadSize(Ar.ReadAt(Header.OffsetInFile, data, offset, Header.ElementCount));
-            }
-            else throw new ParserException(Ar, $"Failed to read PayloadAtEndOfFile, {Header.OffsetInFile} is out of range");
+            position = Header.OffsetInFile;
         }
         else if (BulkDataFlags.HasFlag(BULKDATA_SerializeCompressedZLIB))
         {
-            throw new ParserException(Ar, "TODO: CompressedZlib");
+            throw new ParserException(archive, "TODO: CompressedZlib");
         }
         else if (BulkDataFlags.HasFlag(BULKDATA_LazyLoadable) || BulkDataFlags.HasFlag(BULKDATA_None))
         {
-            CheckReadSize(Ar.Read(data, offset, Header.ElementCount));
+            //
         }
 
-        Ar.Dispose();
+        var read = archive.ReadAt(position, data, offset, Header.ElementCount);
+        if (read != Header.ElementCount)
+        {
+            Log.Warning("Read {read} bytes, expected {Header.ElementCount}", read, Header.ElementCount);
+            // return false; // should we???
+        }
         return true;
     }
 

--- a/CUE4Parse/UE4/Assets/Objects/FByteBulkDataHeader.cs
+++ b/CUE4Parse/UE4/Assets/Objects/FByteBulkDataHeader.cs
@@ -7,7 +7,7 @@ using static CUE4Parse.UE4.Assets.Objects.EBulkDataFlags;
 namespace CUE4Parse.UE4.Assets.Objects
 {
     [JsonConverter(typeof(FByteBulkDataHeaderConverter))]
-    public struct FByteBulkDataHeader
+    public readonly struct FByteBulkDataHeader
     {
         public readonly EBulkDataFlags BulkDataFlags;
         public readonly int ElementCount;

--- a/CUE4Parse/UE4/Assets/Objects/FByteBulkDataHeader.cs
+++ b/CUE4Parse/UE4/Assets/Objects/FByteBulkDataHeader.cs
@@ -7,13 +7,16 @@ using static CUE4Parse.UE4.Assets.Objects.EBulkDataFlags;
 namespace CUE4Parse.UE4.Assets.Objects
 {
     [JsonConverter(typeof(FByteBulkDataHeaderConverter))]
-    public readonly struct FByteBulkDataHeader
+    public struct FByteBulkDataHeader
     {
         public readonly EBulkDataFlags BulkDataFlags;
         public readonly int ElementCount;
         public readonly uint SizeOnDisk;
         public readonly long OffsetInFile;
         public readonly FBulkDataCookedIndex CookedIndex;
+
+        // TODO: remove this once all AbstractVfsReader.Extract(VfsEntry) methods support extracting from headers or whatever this feature will be called
+        internal bool NeedsSeeking = true;
 
         public FByteBulkDataHeader(FAssetArchive Ar)
         {

--- a/CUE4Parse/UE4/Assets/Objects/FByteBulkDataHeader.cs
+++ b/CUE4Parse/UE4/Assets/Objects/FByteBulkDataHeader.cs
@@ -15,9 +15,6 @@ namespace CUE4Parse.UE4.Assets.Objects
         public readonly long OffsetInFile;
         public readonly FBulkDataCookedIndex CookedIndex;
 
-        // TODO: remove this once all AbstractVfsReader.Extract(VfsEntry) methods support extracting from headers or whatever this feature will be called
-        internal bool NeedsSeeking = true;
-
         public FByteBulkDataHeader(FAssetArchive Ar)
         {
             CookedIndex = FBulkDataCookedIndex.Default;

--- a/CUE4Parse/UE4/Assets/Package.cs
+++ b/CUE4Parse/UE4/Assets/Package.cs
@@ -5,6 +5,7 @@ using System.IO;
 using CUE4Parse.FileProvider;
 using CUE4Parse.GameTypes.ACE7.Encryption;
 using CUE4Parse.UE4.Assets.Exports;
+using CUE4Parse.UE4.Assets.Objects;
 using CUE4Parse.UE4.Assets.Readers;
 using CUE4Parse.UE4.Assets.Utils;
 using CUE4Parse.UE4.IO.Objects;
@@ -39,8 +40,8 @@ namespace CUE4Parse.UE4.Assets
             : this(
                 uasset,
                 uexp,
-                ubulk != null ? new Lazy<FArchive?>(() => ubulk) : null,
-                uptnl != null ? new Lazy<FArchive?>(() => uptnl) : null,
+                ubulk != null ? _ => ubulk : null,
+                uptnl != null ? _ => uptnl : null,
                 provider,
                 useLazySerialization)
         { }
@@ -58,8 +59,8 @@ namespace CUE4Parse.UE4.Assets
         public Package(
             FArchive uasset,
             FArchive? uexp,
-            Lazy<FArchive?>? ubulk = null,
-            Lazy<FArchive?>? uptnl = null,
+            Func<FByteBulkDataHeader?, FArchive?>? ubulk = null,
+            Func<FByteBulkDataHeader?, FArchive?>? uptnl = null,
             IFileProvider? provider = null,
             bool useLazySerialization = true)
             : base(uasset.Name.SubstringBeforeLast('.'), provider)

--- a/CUE4Parse/UE4/Assets/Readers/FAssetArchive.cs
+++ b/CUE4Parse/UE4/Assets/Readers/FAssetArchive.cs
@@ -6,6 +6,7 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using CUE4Parse.UE4.Assets.Exports;
+using CUE4Parse.UE4.Assets.Objects;
 using CUE4Parse.UE4.Assets.Utils;
 using CUE4Parse.UE4.Exceptions;
 using CUE4Parse.UE4.Objects.UObject;
@@ -16,7 +17,7 @@ namespace CUE4Parse.UE4.Assets.Readers
 {
     public class FAssetArchive : FArchive
     {
-        private readonly Dictionary<PayloadType, Lazy<FAssetArchive?>> _payloads;
+        private readonly Dictionary<PayloadType, Func<FByteBulkDataHeader?, FAssetArchive?>> _payloads;
         private readonly FArchive _baseArchive;
 
         public readonly IPackage? Owner;
@@ -26,9 +27,9 @@ namespace CUE4Parse.UE4.Assets.Readers
         public bool IsFilterEditorOnly => Owner?.HasFlags(EPackageFlags.PKG_FilterEditorOnly) ?? false;
         public bool IsLoadingFromCookedPackage => Owner?.HasFlags(EPackageFlags.PKG_Cooked) ?? false;
 
-        public FAssetArchive(FArchive baseArchive, IPackage? owner, int absoluteOffset = 0, Dictionary<PayloadType, Lazy<FAssetArchive?>>? payloads = null) : base(baseArchive.Versions)
+        public FAssetArchive(FArchive baseArchive, IPackage? owner, int absoluteOffset = 0, Dictionary<PayloadType, Func<FByteBulkDataHeader?, FAssetArchive?>>? payloads = null) : base(baseArchive.Versions)
         {
-            _payloads = payloads ?? new Dictionary<PayloadType, Lazy<FAssetArchive?>>();
+            _payloads = payloads ?? new Dictionary<PayloadType, Func<FByteBulkDataHeader?, FAssetArchive?>>();
             _baseArchive = baseArchive;
             Owner = owner;
             AbsoluteOffset = absoluteOffset;
@@ -102,11 +103,11 @@ namespace CUE4Parse.UE4.Assets.Readers
 
         public override UObject? ReadUObject() => ReadObject<UObject>().Value;
 
-        public bool TryGetPayload(PayloadType type, [MaybeNullWhen(false)] out FAssetArchive ar)
+        public bool TryGetPayload(PayloadType type, [MaybeNullWhen(false)] out FAssetArchive ar, FByteBulkDataHeader? header = null)
         {
             try
             {
-                ar = GetPayload(type);
+                ar = GetPayload(type, header);
             }
             catch
             {
@@ -115,10 +116,10 @@ namespace CUE4Parse.UE4.Assets.Readers
             return ar != null;
         }
 
-        public FAssetArchive GetPayload(PayloadType type)
+        public FAssetArchive GetPayload(PayloadType type, FByteBulkDataHeader? header = null)
         {
             _payloads.TryGetValue(type, out var ret);
-            var reader = ret?.Value;
+            var reader = ret?.Invoke(header);
             return reader ?? throw new ParserException(this, $"Requested payload of type {type} was not found");
         }
 
@@ -129,21 +130,21 @@ namespace CUE4Parse.UE4.Assets.Readers
                 throw new ParserException(this, $"Can't add a payload that is already attached of type {type}");
             }
 
-            _payloads[type] = new Lazy<FAssetArchive?>(() => payload);
+            _payloads[type] = _ => payload;
         }
 
-        public void AddPayload(PayloadType type, int absoluteOffset, Lazy<FArchive?> payload)
+        public void AddPayload(PayloadType type, int absoluteOffset, Func<FByteBulkDataHeader?, FArchive?> payload)
         {
             if (_payloads.ContainsKey(type))
             {
                 throw new ParserException(this, $"Can't add a payload that is already attached of type {type}");
             }
 
-            _payloads[type] = new Lazy<FAssetArchive?>(() =>
+            _payloads[type] = header =>
             {
-                var rawAr = payload.Value;
+                var rawAr = payload.Invoke(header);
                 return rawAr == null ? null : new FAssetArchive(rawAr, Owner, absoluteOffset);
-            });
+            };
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/CUE4Parse/UE4/IO/IoStoreOnDemandReader.cs
+++ b/CUE4Parse/UE4/IO/IoStoreOnDemandReader.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using CUE4Parse.Encryption.Aes;
+using CUE4Parse.UE4.Assets.Objects;
 using CUE4Parse.UE4.Exceptions;
 using CUE4Parse.UE4.IO.Objects;
 using CUE4Parse.UE4.Readers;
@@ -23,7 +24,7 @@ namespace CUE4Parse.UE4.IO
             _downloader = downloader;
         }
 
-        public override byte[] Extract(VfsEntry entry)
+        public override byte[] Extract(VfsEntry entry, FByteBulkDataHeader? header = null)
         {
             if (!(entry is FIoStoreEntry ioEntry) || entry.Vfs != this) throw new ArgumentException($"Wrong io store reader, required {entry.Vfs.Path}, this is {Path}");
             return Read(Entries[ioEntry.TocEntryIndex]);

--- a/CUE4Parse/UE4/IO/IoStoreReader.cs
+++ b/CUE4Parse/UE4/IO/IoStoreReader.cs
@@ -126,7 +126,6 @@ public partial class IoStoreReader : AbstractAesVfsReader
         var size = ioEntry.Size;
         if (header is { } bulk)
         {
-            bulk.NeedsSeeking = false;
             offset += bulk.OffsetInFile;
             size = bulk.ElementCount;
         }

--- a/CUE4Parse/UE4/IO/IoStoreReader.cs
+++ b/CUE4Parse/UE4/IO/IoStoreReader.cs
@@ -8,6 +8,7 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using CUE4Parse.Encryption.Aes;
 using CUE4Parse.FileProvider.Objects;
+using CUE4Parse.UE4.Assets.Objects;
 using CUE4Parse.UE4.Exceptions;
 using CUE4Parse.UE4.IO.Objects;
 using CUE4Parse.UE4.Objects.Core.Misc;
@@ -117,10 +118,20 @@ public partial class IoStoreReader : AbstractAesVfsReader
         }
     }
 
-    public override byte[] Extract(VfsEntry entry)
+    public override byte[] Extract(VfsEntry entry, FByteBulkDataHeader? header = null)
     {
         if (!(entry is FIoStoreEntry ioEntry) || entry.Vfs != this) throw new ArgumentException($"Wrong io store reader, required {entry.Vfs.Path}, this is {Path}");
-        return Read(ioEntry.Offset, ioEntry.Size);
+
+        var offset = ioEntry.Offset;
+        var size = ioEntry.Size;
+        if (header is { } bulk)
+        {
+            bulk.NeedsSeeking = false;
+            offset += bulk.OffsetInFile;
+            size = bulk.ElementCount;
+        }
+
+        return Read(offset, size);
     }
 
     // If anyone really comes to read this here are some of my thoughts on designing loading of chunk ids

--- a/CUE4Parse/UE4/IO/Objects/FIoStoreEntry.cs
+++ b/CUE4Parse/UE4/IO/Objects/FIoStoreEntry.cs
@@ -1,5 +1,6 @@
 ﻿using System.Runtime.CompilerServices;
 using CUE4Parse.Compression;
+using CUE4Parse.UE4.Assets.Objects;
 using CUE4Parse.UE4.Readers;
 using CUE4Parse.UE4.VirtualFileSystem;
 
@@ -45,9 +46,10 @@ namespace CUE4Parse.UE4.IO.Objects
             get => (IoStoreReader) Vfs;
         }
 
-        public override byte[] Read() => Vfs.Extract(this);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public override byte[] Read(FByteBulkDataHeader? header = null) => Vfs.Extract(this, header);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public override FArchive CreateReader() => new FByteArchive(Path, Read(), Vfs.Versions);
+        public override FArchive CreateReader(FByteBulkDataHeader? header = null) => new FByteArchive(Path, Read(header), Vfs.Versions);
     }
 }

--- a/CUE4Parse/UE4/Pak/Objects/FPakEntry.cs
+++ b/CUE4Parse/UE4/Pak/Objects/FPakEntry.cs
@@ -2,6 +2,7 @@ using System;
 using System.Runtime.CompilerServices;
 using CUE4Parse.Compression;
 using CUE4Parse.Encryption.Aes;
+using CUE4Parse.UE4.Assets.Objects;
 using CUE4Parse.UE4.Objects.Core.Misc;
 using CUE4Parse.UE4.Readers;
 using CUE4Parse.UE4.Versions;
@@ -447,10 +448,10 @@ public class FPakEntry : VfsEntry
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public override byte[] Read() => Vfs.Extract(this);
+    public override byte[] Read(FByteBulkDataHeader? header = null)  => Vfs.Extract(this, header);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public override FArchive CreateReader() => new FByteArchive(Path, Read(), Vfs.Versions);
+    public override FArchive CreateReader(FByteBulkDataHeader? header = null) => new FByteArchive(Path, Read(header), Vfs.Versions);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public FPakEntry(PakFileReader reader, string path, FArchive Ar, EGame game) : base(reader, path)

--- a/CUE4Parse/UE4/Pak/PakFileReader.cs
+++ b/CUE4Parse/UE4/Pak/PakFileReader.cs
@@ -83,7 +83,6 @@ namespace CUE4Parse.UE4.Pak
             var requestedSize = (int) pakEntry.UncompressedSize;
             if (header is { } bulk)
             {
-                bulk.NeedsSeeking = false;
                 offset = (int) bulk.OffsetInFile;
                 requestedSize = bulk.ElementCount;
             }

--- a/CUE4Parse/UE4/Pak/PakFileReader.cs
+++ b/CUE4Parse/UE4/Pak/PakFileReader.cs
@@ -8,6 +8,7 @@ using CommunityToolkit.HighPerformance.Buffers;
 using CUE4Parse.Encryption.Aes;
 using CUE4Parse.FileProvider.Objects;
 using CUE4Parse.GameTypes.Rennsport.Encryption.Aes;
+using CUE4Parse.UE4.Assets.Objects;
 using CUE4Parse.UE4.Exceptions;
 using CUE4Parse.UE4.Objects.Core.Misc;
 using CUE4Parse.UE4.Pak.Objects;
@@ -71,11 +72,22 @@ namespace CUE4Parse.UE4.Pak
         public PakFileReader(string filePath, RandomAccessStream stream, VersionContainer? versions = null)
             : this(new FRandomAccessStreamArchive(filePath, stream, versions)) {}
 
-        public override byte[] Extract(VfsEntry entry)
+        public override byte[] Extract(VfsEntry entry, FByteBulkDataHeader? header = null)
         {
             if (entry is not FPakEntry pakEntry || entry.Vfs != this) throw new ArgumentException($"Wrong pak file reader, required {entry.Vfs.Name}, this is {Name}");
             // If this reader is used as a concurrent reader create a clone of the main reader to provide thread safety
             var reader = IsConcurrent ? (FArchive) Ar.Clone() : Ar;
+            var alignment = pakEntry.IsEncrypted ? Aes.ALIGN : 1;
+
+            var offset = 0;
+            var requestedSize = (int) pakEntry.UncompressedSize;
+            if (header is { } bulk)
+            {
+                bulk.NeedsSeeking = false;
+                offset = (int) bulk.OffsetInFile;
+                requestedSize = bulk.ElementCount;
+            }
+
             if (pakEntry.IsCompressed)
             {
 #if DEBUG
@@ -95,23 +107,46 @@ namespace CUE4Parse.UE4.Pak
                         return ABIExtract(reader, pakEntry);
                 }
 
-                var uncompressed = new byte[(int) pakEntry.UncompressedSize];
-                var uncompressedOff = 0;
-                foreach (var block in pakEntry.CompressionBlocks)
+                var compressionBlockSize = (int) pakEntry.CompressionBlockSize;
+                var firstBlockIndex = offset / compressionBlockSize;
+                var lastBlockIndex = (offset + requestedSize - 1) / compressionBlockSize;
+
+                // blocks are full size, except potentially the last one
+                var numBlocks = lastBlockIndex - firstBlockIndex + 1;
+                var bufferSize = numBlocks * compressionBlockSize;
+                if (lastBlockIndex == (int)((pakEntry.UncompressedSize - 1) / compressionBlockSize))
                 {
+                    var lastBlockInFileSize = (int)(pakEntry.UncompressedSize % compressionBlockSize);
+                    if (lastBlockInFileSize > 0)
+                        bufferSize -= compressionBlockSize - lastBlockInFileSize;
+                }
+
+                var uncompressed = new byte[bufferSize];
+                var uncompressedOff = 0;
+
+                // decompress the required blocks
+                for (var blockIndex = firstBlockIndex; blockIndex <= lastBlockIndex; blockIndex++)
+                {
+                    var block = pakEntry.CompressionBlocks[blockIndex];
                     var blockSize = (int) block.Size;
-                    var srcSize = blockSize.Align(pakEntry.IsEncrypted ? Aes.ALIGN : 1);
+                    var srcSize = blockSize.Align(alignment);
                     // Read the compressed block
                     var compressed = ReadAndDecryptAt(block.CompressedStart, srcSize, reader, pakEntry.IsEncrypted);
                     // Calculate the uncompressed size,
                     // its either just the compression block size,
                     // or if it's the last block, it's the remaining data size
-                    var uncompressedSize = (int) Math.Min(pakEntry.CompressionBlockSize, pakEntry.UncompressedSize - uncompressedOff);
+                    var uncompressedSize = (int) Math.Min(compressionBlockSize, pakEntry.UncompressedSize - blockIndex * compressionBlockSize);
                     Decompress(compressed, 0, blockSize, uncompressed, uncompressedOff, uncompressedSize, pakEntry.CompressionMethod);
-                    uncompressedOff += (int) pakEntry.CompressionBlockSize;
+                    uncompressedOff += uncompressedSize;
                 }
 
-                return uncompressed;
+                var offsetInFirstBlock = offset - firstBlockIndex * compressionBlockSize;
+                if (offsetInFirstBlock == 0 && requestedSize == bufferSize)
+                    return uncompressed;
+
+                var result = new byte[requestedSize];
+                Array.Copy(uncompressed, offsetInFirstBlock, result, 0, requestedSize);
+                return result;
             }
 
             switch (Game)
@@ -129,10 +164,18 @@ namespace CUE4Parse.UE4.Pak
             // Pak Entry is written before the file data,
             // but it's the same as the one from the index, just without a name
             // We don't need to serialize that again so + file.StructSize
-            var size = (int) pakEntry.UncompressedSize.Align(pakEntry.IsEncrypted ? Aes.ALIGN : 1);
-            var data = ReadAndDecryptAt(pakEntry.Offset + pakEntry.StructSize /* Doesn't seem to be the case with older pak versions */,
-                size, reader, pakEntry.IsEncrypted);
-            return size != pakEntry.UncompressedSize ? data.SubByteArray((int) pakEntry.UncompressedSize) : data;
+
+            var readOffset = offset.Align(alignment);
+            var dataOffset = offset - readOffset;
+            var readSize = (dataOffset + requestedSize).Align(alignment);
+            var data = ReadAndDecryptAt(pakEntry.Offset + pakEntry.StructSize + readOffset, readSize, reader, pakEntry.IsEncrypted);
+
+            if (dataOffset == 0 && requestedSize == data.Length)
+                return data;
+
+            var chunk = new byte[requestedSize];
+            Array.Copy(data, dataOffset, chunk, 0, requestedSize);
+            return chunk;
         }
 
         public override void Mount(StringComparer pathComparer)

--- a/CUE4Parse/UE4/VirtualFileSystem/AbstractVfsReader.cs
+++ b/CUE4Parse/UE4/VirtualFileSystem/AbstractVfsReader.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Runtime.CompilerServices;
 using CUE4Parse.FileProvider.Objects;
+using CUE4Parse.UE4.Assets.Objects;
 using CUE4Parse.UE4.Readers;
 using CUE4Parse.UE4.Versions;
 using CUE4Parse.Utils;
@@ -48,7 +49,7 @@ namespace CUE4Parse.UE4.VirtualFileSystem
         }
 
         public abstract void Mount(StringComparer pathComparer);
-        public abstract byte[] Extract(VfsEntry entry);
+        public abstract byte[] Extract(VfsEntry entry, FByteBulkDataHeader? header = null);
 
         protected void ValidateMountPoint(ref string mountPoint)
         {

--- a/CUE4Parse/UE4/VirtualFileSystem/IVfsReader.cs
+++ b/CUE4Parse/UE4/VirtualFileSystem/IVfsReader.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using CUE4Parse.FileProvider.Objects;
 using CUE4Parse.FileProvider.Vfs;
+using CUE4Parse.UE4.Assets.Objects;
 using CUE4Parse.UE4.Versions;
 
 namespace CUE4Parse.UE4.VirtualFileSystem
@@ -26,6 +27,6 @@ namespace CUE4Parse.UE4.VirtualFileSystem
         public void Mount(StringComparer pathComparer);
         public void MountTo(FileProviderDictionary files, StringComparer pathComparer, EventHandler<int>? vfsMounted = null);
 
-        public abstract byte[] Extract(VfsEntry entry);
+        public abstract byte[] Extract(VfsEntry entry, FByteBulkDataHeader? header = null);
     }
 }


### PR DESCRIPTION
so instead of reading the whole data and then let FByteBulkData seek into it, we read only the blocks requested by FByteBulkData, that way we don't waste memory on unrequested data ranges and FByteBulkData doesn't have to seek anymore