### PR TITLE
Fix PSK SKELSOCK

### DIFF
--- a/CUE4Parse-Conversion/Constants.cs
+++ b/CUE4Parse-Conversion/Constants.cs
@@ -18,7 +18,7 @@ public class Constants
     public const int VQuatAnimKey_SIZE = 3 * 4 + 4 * 4 + 4;
     public const int VScaleAnimKey_SIZE = 3 * 4 + 4;
     public const int VMorphData_SIZE = 3 * 4 + 3 * 4 + 4;
-    public const int VSocket_SIZE = 64 + 64 + 3 * 4 + 4 * 4 + 3 * 4;
+    public const int VSocket_SIZE = 64 + 64 + 3 * 4 + 3 * 4 + 3 * 4;
 
     public const int DXT_BITS_PER_PIXEL = 4;
 


### PR DESCRIPTION
The size is actually 0xA4 not 0xA8. FRotator is 3 components, not 4.