### PR TITLE
Hotfix RetargetBasePose being null when it shouldn't

### DIFF
--- a/CUE4Parse-Conversion/Animations/PSA/CAnimSequence.cs
+++ b/CUE4Parse-Conversion/Animations/PSA/CAnimSequence.cs
@@ -23,14 +23,24 @@ namespace CUE4Parse_Conversion.Animations.PSA
         public CAnimSequence(UAnimSequence animSequence, USkeleton skeleton)
         {
             OriginalSequence = animSequence;
-            RetargetBasePose = OriginalSequence.RetargetSource.IsNone switch
+            var retarget = OriginalSequence.RetargetSource;
+            RetargetBasePose = retarget.IsNone switch
             {
                 true when OriginalSequence.RetargetSourceAssetReferencePose is { Length: > 0 }
                     => OriginalSequence.RetargetSourceAssetReferencePose,
-                false when skeleton.AnimRetargetSources.TryGetValue(OriginalSequence.RetargetSource, out var refPose)
+                false when skeleton.AnimRetargetSources.TryGetValue(retarget, out var refPose)
                     => refPose.ReferencePose,
                 _ => null
             };
+
+            // TryGetValue fails half the time :D
+            if (!retarget.IsNone && RetargetBasePose == null) {
+                foreach (var (key, value) in skeleton.AnimRetargetSources) {
+                    if (key.PlainText.Equals(retarget.PlainText)) {
+                        RetargetBasePose = value.ReferencePose;
+                    }
+                }
+            }
 
             Name = OriginalSequence.Name;
             NumFrames = OriginalSequence.NumFrames;


### PR DESCRIPTION
Hotfixes an issue that happens when one of the two is comparing via index and the other via strings (I think? I tried forcing GetHashCode to evaluate the string content and it did not fix it.)

Additive animations (usually faces) and animations using a shared skeleton end up being catastrophically distorted without this change.

Note; if it is an issue with FName comparison in `Dictionary<FName, TValue>` this issue could emerge in other places