### PR TITLE
Fix FloatRGB

### DIFF
--- a/CUE4Parse/UE4/Assets/Exports/Texture/PixelFormat.cs
+++ b/CUE4Parse/UE4/Assets/Exports/Texture/PixelFormat.cs
@@ -28,7 +28,7 @@ public static class PixelFormatUtils
         new(EPixelFormat.PF_DXT3,               "DXT3",                   4,          4,          1,          16,           4,                true),
         new(EPixelFormat.PF_DXT5,               "DXT5",                   4,          4,          1,          16,           4,                true),
         new(EPixelFormat.PF_UYVY,               "UYVY",                   2,          1,          1,          4,            4,                false),
-        new(EPixelFormat.PF_FloatRGB,           "FloatRGB",               1,          1,          1,          4,            3,                true),
+        new(EPixelFormat.PF_FloatRGB,           "FloatRGB",               1,          1,          1,          6,            3,                true),
         new(EPixelFormat.PF_FloatRGBA,          "FloatRGBA",              1,          1,          1,          8,            4,                true),
         new(EPixelFormat.PF_DepthStencil,       "DepthStencil",           1,          1,          1,          4,            1,                false),
         new(EPixelFormat.PF_ShadowDepth,        "ShadowDepth",            1,          1,          1,          4,            1,                false),


### PR DESCRIPTION
It's 6 bytes (half is 2 bytes, 3 components, 2 * 3 = 6 bytes), not 4. Causes an out of bounds read otherwise.

Seen in Steel Hunters (`ProjectR3/Content/Environment/Light/Default_EngineSky/T_Clouds_Terra3_8k01_seq049_x1109.uasset`)