### PR TITLE
Update Psychonauts2.cs

### DIFF
--- a/CUE4Parse/GameTypes/OtherGames/Objects/Psychonauts2.cs
+++ b/CUE4Parse/GameTypes/OtherGames/Objects/Psychonauts2.cs
@@ -74,8 +74,8 @@ public class UStoryData : UObject
     [StructLayout(LayoutKind.Sequential, Pack =1)]
     public struct FP2StoryDataStruct
     {
-        public int LinecodeTableIndex;
         public int TextsIndex;
+        public int DialogueIndex;
         public short CharactersIndex;
         public short CharacterVariantsIndex;
         public short AudioTemplatesIndex;


### PR DESCRIPTION
I’ve renamed LinecodeTableIndex to TextsIndex, as it corresponds to a valid entry in the Texts array. The previous TextsIndex I've renamed to DialogueIndex, since its value is zero for UI strings.

Each integer in a LinecodeTable entry represents an index, mapping the corresponding Linecode to a Data array entry.