### PR TITLE
Fix BitMapData bit index to account for m_BitsPerWord stride

### DIFF
--- a/CUE4Parse/GameTypes/DuneAwakening/Assets/Exports/UBitMapData.cs
+++ b/CUE4Parse/GameTypes/DuneAwakening/Assets/Exports/UBitMapData.cs
@@ -33,7 +33,7 @@ public class UBitMapData : UObject
                 var data = 0;
                 for (var k = 0; k < m_BitsPerWord; k++)
                 {
-                    data |= Data[i * m_SizeY + j] ? 1 << k : 0;
+                    data |= Data[(i * m_SizeY + j) * m_BitsPerWord + k] ? 1 << k : 0;
                 }
 
                 if (data != 0)


### PR DESCRIPTION
The BitArray index was missing the m_BitsPerWord multiplier, causing it to read the same single bit for all k iterations. This resulted in every non-zero value having all bits set and incorrect coordinate mapping.