### PR TITLE
UObjects now stores pointers to their Outer and Class objects

### DIFF
--- a/CUE4Parse/UE4/Assets/AbstractUePackage.cs
+++ b/CUE4Parse/UE4/Assets/AbstractUePackage.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Tasks;
@@ -44,11 +45,12 @@ public abstract class AbstractUePackage : UObject, IPackage
         Flags |= EObjectFlags.RF_WasLoaded;
     }
 
-    public UObject ConstructObject(UStruct? struc, IPackage? owner = null, EObjectFlags flags = EObjectFlags.RF_NoFlags)
+    public UObject ConstructObject(ResolvedObject? struc, IPackage? owner = null, EObjectFlags flags = EObjectFlags.RF_NoFlags)
     {
         UObject? obj = null;
         var mappings = owner?.Mappings;
-        var current = struc;
+        var current = struc?.Object?.Value as UStruct;
+
         while (current != null) // Traverse up until a known one is found
         {
             if (current is UClass scriptClass)
@@ -66,7 +68,7 @@ public abstract class AbstractUePackage : UObject, IPackage
             {
                 // added guard for infinite loop
                 if (string.IsNullOrEmpty(structMappings.SuperType) || previous.Name == structMappings.SuperType) break;
-                current = new UScriptClass(structMappings.SuperType) ;
+                current = new UScriptClass(structMappings.SuperType);
             }
         }
 
@@ -125,17 +127,11 @@ public abstract class AbstractUePackage : UObject, IPackage
 }
 
 [JsonConverter(typeof(ResolvedObjectConverter))]
-public abstract class ResolvedObject : IObject
+public abstract class ResolvedObject(IPackage package, int exportIndex = -1) : IObject
 {
-    public readonly IPackage Package;
+    public readonly IPackage Package = package;
 
-    public ResolvedObject(IPackage package, int exportIndex = -1)
-    {
-        Package = package;
-        ExportIndex = exportIndex;
-    }
-
-    public int ExportIndex { get; }
+    public int ExportIndex { get; } = exportIndex;
     public abstract FName Name { get; }
     public virtual ResolvedObject? Outer => null;
     public virtual ResolvedObject? Class => null;
@@ -189,18 +185,31 @@ public abstract class ResolvedObject : IObject
     public UObject? Load() => Object?.Value;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public bool TryLoad(out UObject export)
+    public bool TryLoad<T>([MaybeNullWhen(false)] out T export) where T : UObject
     {
         try
         {
-            export = Object?.Value;
-            return export != null;
+            export = Load<T>();
         }
         catch
         {
-            export = default;
-            return false;
+            export = null;
         }
+        return export != null;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool TryLoad([MaybeNullWhen(false)] out UObject export)
+    {
+        try
+        {
+            export = Load();
+        }
+        catch
+        {
+            export = null;
+        }
+        return export != null;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -235,32 +244,11 @@ public abstract class ResolvedObject : IObject
     public override string ToString() => GetFullName();
 }
 
-public class ResolvedLoadedObject : ResolvedObject
+public class ResolvedLoadedObject(UObject uobject) : ResolvedObject(uobject.Owner)
 {
-    private readonly UObject _object;
-
-    public ResolvedLoadedObject(UObject obj) : base(obj.Owner)
-    {
-        _object = obj;
-    }
-
-    public override FName Name => new(_object.Name);
-    public override ResolvedObject? Outer
-    {
-        get
-        {
-            var obj = _object.Outer;
-            return obj != null ? new ResolvedLoadedObject(obj) : null;
-        }
-    }
-    public override ResolvedObject? Class
-    {
-        get
-        {
-            var obj = _object.Class;
-            return obj != null ? new ResolvedLoadedObject(obj) : null;
-        }
-    }
-    public override ResolvedObject? Super => null; //new ResolvedLoadedObject(_object.Super);
-    public override Lazy<UObject> Object => new(() => _object);
+    public override FName Name => new(uobject.Name);
+    public override ResolvedObject? Outer => uobject.Outer;
+    public override ResolvedObject? Class => uobject.Class;
+    public override ResolvedObject? Super => uobject.Super;
+    public override Lazy<UObject> Object => new(() => uobject);
 }

--- a/CUE4Parse/UE4/Assets/AbstractUePackage.cs
+++ b/CUE4Parse/UE4/Assets/AbstractUePackage.cs
@@ -252,3 +252,9 @@ public class ResolvedLoadedObject(UObject uobject) : ResolvedObject(uobject.Owne
     public override ResolvedObject? Super => uobject.Super;
     public override Lazy<UObject> Object => new(() => uobject);
 }
+
+public class ResolvedPackageObject(IPackage package) : ResolvedObject(package)
+{
+    public override FName Name => new(Package.Name);
+    public override Lazy<UObject> Object => new(() => (AbstractUePackage) Package);
+}

--- a/CUE4Parse/UE4/Assets/Exports/Animation/AnimBoneCompressionCodec.cs
+++ b/CUE4Parse/UE4/Assets/Exports/Animation/AnimBoneCompressionCodec.cs
@@ -19,10 +19,10 @@ namespace CUE4Parse.UE4.Assets.Exports.Animation
             handle.Append(Name);
 
             var outer = Outer;
-            while (outer?.TryLoad<UAnimBoneCompressionSettings>(out var obj) == true)
+            while (outer?.TryLoad<UAnimBoneCompressionSettings>(out _) == false)
             {
                 handle.Append('.');
-                handle.Append(obj.Name);
+                handle.Append(outer.Name);
                 outer = outer.Outer;
             }
 

--- a/CUE4Parse/UE4/Assets/Exports/Animation/AnimBoneCompressionCodec.cs
+++ b/CUE4Parse/UE4/Assets/Exports/Animation/AnimBoneCompressionCodec.cs
@@ -18,12 +18,12 @@ namespace CUE4Parse.UE4.Assets.Exports.Animation
             var handle = new StringBuilder(128);
             handle.Append(Name);
 
-            var obj = Outer;
-            while (obj != null && obj is not UAnimBoneCompressionSettings)
+            var outer = Outer;
+            while (outer?.TryLoad<UAnimBoneCompressionSettings>(out var obj) == true)
             {
                 handle.Append('.');
                 handle.Append(obj.Name);
-                obj = obj.Outer;
+                outer = outer.Outer;
             }
 
             return handle.ToString();

--- a/CUE4Parse/UE4/Assets/Exports/UObject.cs
+++ b/CUE4Parse/UE4/Assets/Exports/UObject.cs
@@ -111,7 +111,7 @@ public class UObject : AbstractPropertyHolder
     public FStructFallback? SerializedSparseClassData;
 
     // public FObjectExport Export;
-    public IPackage? Owner => Outer?.Package ?? Class?.Package;
+    public IPackage? Owner => Outer?.Package;
     public string ExportType => Class?.Name.Text ?? GetType().Name;
 
     public UObject()
@@ -190,12 +190,6 @@ public class UObject : AbstractPropertyHolder
     public string GetPathName(UObject? stopOuter = null)
     {
         var result = new StringBuilder();
-        if (Owner is UObject uobject)
-        {
-            uobject.GetPathName(stopOuter, result);
-            result.Append('.');
-        }
-
         GetPathName(stopOuter, result);
         return result.ToString();
     }
@@ -211,7 +205,7 @@ public class UObject : AbstractPropertyHolder
             {
                 objOuter.GetPathName(stopOuter, resultString);
                 // SUBOBJECT_DELIMITER_CHAR is used to indicate that this object's outer is not a UPackage
-                resultString.Append(objOuter.Outer is null ? ':' : '.');
+                resultString.Append(objOuter.Outer is ResolvedPackageObject ? ':' : '.');
             }
 
             resultString.Append(Name);
@@ -407,7 +401,7 @@ public class UObject : AbstractPropertyHolder
         }
 
         // outer
-        if (Outer != null)
+        if (Outer != null && Outer is not ResolvedPackageObject)
         {
             writer.WritePropertyName("Outer");
             serializer.Serialize(writer, Outer);

--- a/CUE4Parse/UE4/Assets/Exports/UObject.cs
+++ b/CUE4Parse/UE4/Assets/Exports/UObject.cs
@@ -111,7 +111,7 @@ public class UObject : AbstractPropertyHolder
     public FStructFallback? SerializedSparseClassData;
 
     // public FObjectExport Export;
-    public IPackage? Owner => Class?.Package;
+    public IPackage? Owner => Outer?.Package ?? Class?.Package;
     public string ExportType => Class?.Name.Text ?? GetType().Name;
 
     public UObject()

--- a/CUE4Parse/UE4/Assets/Exports/UObject.cs
+++ b/CUE4Parse/UE4/Assets/Exports/UObject.cs
@@ -400,10 +400,10 @@ public class UObject : AbstractPropertyHolder
         writer.WriteValue(Flags.ToStringBitfield());
 
         // class
-        if (Class != null)
+        if (Class is { Object.Value: { } clas })
         {
             writer.WritePropertyName("Class");
-            writer.WriteValue(Class.GetFullName());
+            writer.WriteValue(clas.GetFullName());
         }
 
         // outer

--- a/CUE4Parse/UE4/Assets/IoPackage.cs
+++ b/CUE4Parse/UE4/Assets/IoPackage.cs
@@ -244,6 +244,7 @@ public sealed class IoPackage : AbstractUePackage
                 var obj = ConstructObject(ResolveObjectIndex(export.ClassIndex), this, export.ObjectFlags);
                 obj.Name = CreateFNameFromMappedName(export.ObjectName).Text;
                 obj.Outer = ResolveObjectIndex(export.OuterIndex) as ResolvedExportObject;
+                obj.Outer ??= new ResolvedPackageObject(this);
                 obj.Super = ResolveObjectIndex(export.SuperIndex) as ResolvedExportObject;
                 obj.Template = ResolveObjectIndex(export.TemplateIndex) as ResolvedExportObject;
                 obj.Flags |= export.ObjectFlags; // We give loaded objects the RF_WasLoaded flag in ConstructObject, so don't remove it again in here

--- a/CUE4Parse/UE4/Assets/IoPackage.cs
+++ b/CUE4Parse/UE4/Assets/IoPackage.cs
@@ -241,11 +241,9 @@ public sealed class IoPackage : AbstractUePackage
             ExportsLazy[entry.LocalExportIndex] = new Lazy<UObject>(() =>
             {
                 // Create
-                var clas = ResolveObjectIndex(export.ClassIndex);
-                var struc = clas?.Object?.Value as UStruct;
-                var obj = ConstructObject(struc, this, export.ObjectFlags);
+                var obj = ConstructObject(ResolveObjectIndex(export.ClassIndex), this, export.ObjectFlags);
                 obj.Name = CreateFNameFromMappedName(export.ObjectName).Text;
-                obj.Outer = (ResolveObjectIndex(export.OuterIndex) as ResolvedExportObject)?.Object?.Value ?? this;
+                obj.Outer = ResolveObjectIndex(export.OuterIndex) as ResolvedExportObject;
                 obj.Super = ResolveObjectIndex(export.SuperIndex) as ResolvedExportObject;
                 obj.Template = ResolveObjectIndex(export.TemplateIndex) as ResolvedExportObject;
                 obj.Flags |= export.ObjectFlags; // We give loaded objects the RF_WasLoaded flag in ConstructObject, so don't remove it again in here

--- a/CUE4Parse/UE4/Assets/Package.cs
+++ b/CUE4Parse/UE4/Assets/Package.cs
@@ -199,6 +199,7 @@ namespace CUE4Parse.UE4.Assets
                         var obj = ConstructObject(ResolvePackageIndex(export.ClassIndex), this, (EObjectFlags) export.ObjectFlags);
                         obj.Name = export.ObjectName.Text;
                         obj.Outer = ResolvePackageIndex(export.OuterIndex) as ResolvedExportObject;
+                        obj.Outer ??= new ResolvedPackageObject(this);
                         obj.Super = ResolvePackageIndex(export.SuperIndex) as ResolvedExportObject;
                         obj.Template = ResolvePackageIndex(export.TemplateIndex) as ResolvedExportObject;
                         obj.Flags |= (EObjectFlags) export.ObjectFlags; // We give loaded objects the RF_WasLoaded flag in ConstructObject, so don't remove it again in here
@@ -482,6 +483,7 @@ namespace CUE4Parse.UE4.Assets
                 _object = _package.ConstructObject(_package.ResolvePackageIndex(_export.ClassIndex), _package, (EObjectFlags) _export.ObjectFlags);
                 _object.Name = _export.ObjectName.Text;
                 _object.Outer = _package.ResolvePackageIndex(_export.OuterIndex) as ResolvedExportObject;
+                _object.Outer ??= new ResolvedPackageObject(_package);
                 _object.Super = _package.ResolvePackageIndex(_export.SuperIndex) as ResolvedExportObject;
                 _object.Template = _package.ResolvePackageIndex(_export.TemplateIndex) as ResolvedExportObject;
                 _object.Flags |= (EObjectFlags) _export.ObjectFlags; // We give loaded objects the RF_WasLoaded flag in ConstructObject, so don't remove it again in here

--- a/CUE4Parse/UE4/Assets/Package.cs
+++ b/CUE4Parse/UE4/Assets/Package.cs
@@ -196,9 +196,9 @@ namespace CUE4Parse.UE4.Assets
                     ExportsLazy[i] = new Lazy<UObject>(() =>
                     {
                         // Create
-                        var obj = ConstructObject(ResolvePackageIndex(export.ClassIndex)?.Object?.Value as UStruct, this, (EObjectFlags) export.ObjectFlags);
+                        var obj = ConstructObject(ResolvePackageIndex(export.ClassIndex), this, (EObjectFlags) export.ObjectFlags);
                         obj.Name = export.ObjectName.Text;
-                        obj.Outer = (ResolvePackageIndex(export.OuterIndex) as ResolvedExportObject)?.Object.Value ?? this;
+                        obj.Outer = ResolvePackageIndex(export.OuterIndex) as ResolvedExportObject;
                         obj.Super = ResolvePackageIndex(export.SuperIndex) as ResolvedExportObject;
                         obj.Template = ResolvePackageIndex(export.TemplateIndex) as ResolvedExportObject;
                         obj.Flags |= (EObjectFlags) export.ObjectFlags; // We give loaded objects the RF_WasLoaded flag in ConstructObject, so don't remove it again in here
@@ -479,17 +479,9 @@ namespace CUE4Parse.UE4.Assets
             {
                 Trace.Assert(_phase == LoadPhase.Create);
                 _phase = LoadPhase.Serialize;
-                _object = _package.ConstructObject(_package.ResolvePackageIndex(_export.ClassIndex)?.Object?.Value as UStruct, _package, (EObjectFlags) _export.ObjectFlags);
+                _object = _package.ConstructObject(_package.ResolvePackageIndex(_export.ClassIndex), _package, (EObjectFlags) _export.ObjectFlags);
                 _object.Name = _export.ObjectName.Text;
-                if (!_export.OuterIndex.IsNull)
-                {
-                    Trace.Assert(_export.OuterIndex.IsExport, "Outer imports are not yet supported");
-                    _object.Outer = _package._exportLoaders[_export.OuterIndex.Index - 1]._object;
-                }
-                else
-                {
-                    _object.Outer = _package;
-                }
+                _object.Outer = _package.ResolvePackageIndex(_export.OuterIndex) as ResolvedExportObject;
                 _object.Super = _package.ResolvePackageIndex(_export.SuperIndex) as ResolvedExportObject;
                 _object.Template = _package.ResolvePackageIndex(_export.TemplateIndex) as ResolvedExportObject;
                 _object.Flags |= (EObjectFlags) _export.ObjectFlags; // We give loaded objects the RF_WasLoaded flag in ConstructObject, so don't remove it again in here

--- a/CUE4Parse/UE4/Objects/UObject/UStruct.cs
+++ b/CUE4Parse/UE4/Objects/UObject/UStruct.cs
@@ -52,7 +52,7 @@ public class UStruct : UField
                 }
             }
             catch (Exception e)
-            { 
+            {
                 Log.Warning(e, $"Failed to serialize script bytecode in {Name}");
             }
             finally


### PR DESCRIPTION
TLDR: this basically restrain the package from resolving Outer and Class objects instantly at the object construction level, for no real use there. Outer and Class objects are now pointers which makes #320 possible without calling GetPathName on every exports of a package.

---

Because
- constructing an export requires constructing a resolvable index to the Class, Outer, Super, and Template objects
- and our old UObject requiring a typed version of Class and Outer

we used to resolve both Outer and Class to their actual typed value. But it turns out we should not have to, as both can be resolved whenever we need them.

For example we needed Outer to grab the IPackage Owner back from the export we used to be in ([see](https://github.com/FabianFG/CUE4Parse/blob/master/CUE4Parse/UE4/Assets/Exports/UObject.cs#L114-L132)), so not only every export parsed its parent before parsing itself ([see](https://github.com/FabianFG/CUE4Parse/blob/master/CUE4Parse/UE4/Assets/IoPackage.cs#L248)), but we had to loop until we find the top most parent in order to get its package.

Now Class can give us that Owner without parsing, neither Class nor Outer ([see](https://github.com/FabianFG/CUE4Parse/blob/uobject-hierarchy/CUE4Parse/UE4/Assets/Exports/UObject.cs#L114)).
This works because resolvable objects can't be constructed without a IPackage ([see](https://github.com/FabianFG/CUE4Parse/blob/master/CUE4Parse/UE4/Assets/AbstractUePackage.cs#L132)), and an object without a class is basically a broken object.

---

This however changes the way we see UObjects and may be different from what UE does.

1. Before this change, the Outer of a top level export was basically the Owner, that's why when writing Outer in the json we had to check if Outer was not Owner ([see](https://github.com/FabianFG/CUE4Parse/blob/master/CUE4Parse/UE4/Assets/Exports/UObject.cs#L410)). And Owner was referencing itself via Owner over and over again. Now a top level export does not have any Outer, as it should, and its Owner neither have an Outer nor an Owner.

Before
<img width="564" height="375" alt="image" src="https://github.com/user-attachments/assets/bd926779-307a-4a02-a066-1c8a44d2d48f" />
After
<img width="476" height="169" alt="image" src="https://github.com/user-attachments/assets/8344004c-b787-4a67-a4f5-77836cc0bd4a" />

3. Because we broke the recursivity on Outer, we also broke GetPathName so I had to make an [ugly fix](https://github.com/FabianFG/CUE4Parse/blob/uobject-hierarchy/CUE4Parse/UE4/Assets/Exports/UObject.cs#L193-L197). But technically now we don't even need to parse Outer to build a path, which is nice, but not implemented. 

4. Whenever we need Outer or Class, we have to parse it either via Class.Object.Value or Class.Load/TryLoad. But Object being lazy, it should have minor impact when calling the actual typed object multiple times at multiple places.