### PR TITLE
Fix FByteBulkData position skip for IoStore BulkDataMap packages

### DIFF
--- a/CUE4Parse/UE4/Assets/Objects/FByteBulkData.cs
+++ b/CUE4Parse/UE4/Assets/Objects/FByteBulkData.cs
@@ -82,12 +82,25 @@ public class FByteBulkData
             return;
         }
 
-        _dataPosition = Ar.Position;
         _savedAr = Ar;
 
-        if (BulkDataFlags.HasFlag(BULKDATA_ForceInlinePayload) || BulkDataFlags is BULKDATA_LazyLoadable or BULKDATA_None)
+        // For IoStore packages with BulkDataMap, the data is at a pre-determined offset
+        // (Header.OffsetInFile relative to BulkDataStartOffset), NOT at the current
+        // sequential read position. The serialization only writes a 4-byte dataIndex
+        // to reference the BulkDataMap entry — the reader must not skip past inline data.
+        var usedBulkDataMap = Ar.Owner is IoPackage { BulkDataMap.Length: > 0 };
+
+        if (usedBulkDataMap)
         {
-            Ar.Position += Header.SizeOnDisk;
+            _dataPosition = Header.OffsetInFile + (Ar.Owner?.Summary.BulkDataStartOffset ?? 0);
+        }
+        else
+        {
+            _dataPosition = Ar.Position;
+            if (BulkDataFlags.HasFlag(BULKDATA_ForceInlinePayload) || BulkDataFlags is BULKDATA_LazyLoadable or BULKDATA_None)
+            {
+                Ar.Position += Header.SizeOnDisk;
+            }
         }
 
         if (LazyLoad)


### PR DESCRIPTION
## Problem

For IoStore packages that use `BulkDataMap`, `FByteBulkData` incorrectly advances `Ar.Position` by `SizeOnDisk` after reading the header. In IoStore, the header is just a 4-byte `dataIndex` referencing the `BulkDataMap` — the actual bulk data is at a pre-determined offset (`Header.OffsetInFile + BulkDataStartOffset`), not at the current sequential read position.

This causes all downstream readers (notably `FNaniteResources`) to read from wrong archive positions, producing:
```
Read size is bigger than remaining archive length
```
**Every `UStaticMesh` in Fortnite v40.x (UE5.8) fails to deserialize `RenderData`**, resulting in `RenderData = null` and 0% mesh export success rate.

## Root Cause

In `FByteBulkData(FAssetArchive Ar)`:
```csharp
_dataPosition = Ar.Position;
Ar.Position += Header.SizeOnDisk; // ← WRONG for BulkDataMap
```

When `FByteBulkDataHeader` resolves via `BulkDataMap` (IoStore path), the serialization only wrote a 4-byte index — there is no inline data to skip past. The `SizeOnDisk` from the map describes where the data lives, not how much to advance the sequential reader.

## Fix

When the header was resolved via `BulkDataMap` (`IoPackage.BulkDataMap.Length > 0`):
- Set `_dataPosition` to the map-specified offset (`Header.OffsetInFile + BulkDataStartOffset`)
- Do **not** advance `Ar.Position`

Legacy (non-BulkDataMap) behavior is unchanged.

## Testing

Tested on Fortnite v40.10 and v40.20:
- **Before**: 0/11 StaticMesh exports succeeded (`RenderData` always null)
- **After**: 11/11 succeeded — meshes from all eras (Figment/OG, Helios/Ch5, BlastBerry, classic `/Game/`) export correctly with full LODs and Nanite data