### PR TITLE
Add SourceContext to Serilog Logs

### DIFF
--- a/CUE4Parse-Conversion/Meshes/MeshConverter.cs
+++ b/CUE4Parse-Conversion/Meshes/MeshConverter.cs
@@ -30,6 +30,8 @@ namespace CUE4Parse_Conversion.Meshes;
 
 public static class MeshConverter
 {
+    private static ILogger Log = Serilog.Log.ForContext(typeof(MeshConverter));
+    
     public static bool TryConvert(this USkeleton originalSkeleton, out List<CSkelMeshBone> bones, out FBox box)
     {
         bones = new List<CSkelMeshBone>();

--- a/CUE4Parse-Conversion/Meshes/MeshExporter.cs
+++ b/CUE4Parse-Conversion/Meshes/MeshExporter.cs
@@ -10,10 +10,8 @@ using CUE4Parse_Conversion.Materials;
 using CUE4Parse_Conversion.Meshes.glTF;
 using CUE4Parse_Conversion.Meshes.PSK;
 using CUE4Parse_Conversion.Meshes.UEFormat;
-using CUE4Parse.UE4.Assets;
 using CUE4Parse.UE4.Assets.Exports.Component.SplineMesh;
 using CUE4Parse.UE4.Assets.Exports.Rig;
-using CUE4Parse.UE4.Objects.PhysicsEngine;
 using CUE4Parse.UE4.Objects.UObject;
 using CUE4Parse.Utils;
 using Serilog;
@@ -22,6 +20,8 @@ namespace CUE4Parse_Conversion.Meshes
 {
     public class MeshExporter : ExporterBase
     {
+        private static readonly ILogger Log = Serilog.Log.ForContext<MeshExporter>();
+        
         public readonly List<Mesh> MeshLods;
         public readonly List<DNAExporter> DNAAssets = [];
 
@@ -65,7 +65,7 @@ namespace CUE4Parse_Conversion.Meshes
 
             if (!originalMesh.TryConvert(splineMeshComponent, out var convertedMesh, options.NaniteMeshFormat) || convertedMesh.LODs.Count == 0)
             {
-                Log.Logger.Warning($"Mesh '{ExportName}' has no LODs");
+                Log.Warning($"Mesh '{ExportName}' has no LODs");
                 return;
             }
 

--- a/CUE4Parse-Conversion/PoseAsset/PoseAssetExporter.cs
+++ b/CUE4Parse-Conversion/PoseAsset/PoseAssetExporter.cs
@@ -9,6 +9,8 @@ namespace CUE4Parse_Conversion.PoseAsset;
 
 public class PoseAssetExporter : ExporterBase
 {
+    private static readonly ILogger Log = Serilog.Log.ForContext<PoseAssetExporter>();
+    
     public PoseAsset PoseAsset;
 
     public PoseAssetExporter(UPoseAsset poseAsset, ExporterOptions options) : base(poseAsset, options)

--- a/CUE4Parse-Conversion/Textures/BC/DetexHelper.cs
+++ b/CUE4Parse-Conversion/Textures/BC/DetexHelper.cs
@@ -10,6 +10,8 @@ namespace CUE4Parse_Conversion.Textures.BC;
 
 public static class DetexHelper
 {
+    private static readonly ILogger Log = Serilog.Log.ForContext(typeof(DetexHelper));
+    
     private const string MANIFEST_URL = "CUE4Parse_Conversion.Resources.Detex.dll";
     public const string DLL_NAME = "Detex.dll";
 

--- a/CUE4Parse.Example/Exporter.cs
+++ b/CUE4Parse.Example/Exporter.cs
@@ -42,6 +42,11 @@ public enum ExportType
 
 public static class Exporter
 {
+    private static readonly ILogger Log = new LoggerConfiguration()
+        .WriteTo.Console(theme: AnsiConsoleTheme.Literate)
+        .CreateLogger()
+        .ForContext(typeof(Exporter));
+    
     private const string _archiveDirectory = "D:\\Games\\Fortnite\\FortniteGame\\Content\\Paks";
     private const string _aesKey = "0x61D4FD0F3AC7768A08E82A99D275A13762A299FCC28CCF53C46BB221BB90D2B8";
     private const string _mapping = "./++Fortnite+Release-33.20-CL-39082670-Windows_oo.usmap";
@@ -52,8 +57,6 @@ public static class Exporter
 
     private static void Export(ExportType type)
     {
-        Log.Logger = new LoggerConfiguration().WriteTo.Console(theme: AnsiConsoleTheme.Literate).CreateLogger();
-
         ZlibHelper.Initialize();
         OodleHelper.Initialize();
 

--- a/CUE4Parse.Example/Program.cs
+++ b/CUE4Parse.Example/Program.cs
@@ -1,12 +1,9 @@
 using System;
-using System.IO;
 using CUE4Parse.Encryption.Aes;
 using CUE4Parse.FileProvider;
 using CUE4Parse.UE4.Objects.Core.Misc;
 using CUE4Parse.UE4.Versions;
 using Newtonsoft.Json;
-using Serilog;
-using Serilog.Sinks.SystemConsole.Themes;
 
 namespace CUE4Parse.Example
 {
@@ -27,8 +24,6 @@ namespace CUE4Parse.Example
 
         public static void Main()
         {
-            Log.Logger = new LoggerConfiguration().WriteTo.Console(theme: AnsiConsoleTheme.Literate).CreateLogger();
-
             var provider = new ApkFileProvider(@"C:\Users\valen\Downloads\ZqOY4K41h0N_Qb6WjEe23TlGExojpQ.apk", new VersionContainer(EGame.GAME_UE5_3));
             // var provider = new DefaultFileProvider(_gameDirectory, SearchOption.TopDirectoryOnly, true, new VersionContainer(EGame.GAME_UE5_3));
             // provider.MappingsContainer = new FileUsmapTypeMappingsProvider(_mapping);

--- a/CUE4Parse.Example/Unpacker.cs
+++ b/CUE4Parse.Example/Unpacker.cs
@@ -15,6 +15,11 @@ namespace CUE4Parse.Example;
 
 public static class Unpacker
 {
+    private static readonly ILogger Log = new LoggerConfiguration()
+        .WriteTo.Console(theme: AnsiConsoleTheme.Literate)
+        .CreateLogger()
+        .ForContext(typeof(Unpacker));
+    
     private const string _archiveDirectory = "D:\\Games\\Fortnite\\FortniteGame\\Content\\Paks";
     private const string _aesKey = "0x61D4FD0F3AC7768A08E82A99D275A13762A299FCC28CCF53C46BB221BB90D2B8";
 
@@ -22,8 +27,6 @@ public static class Unpacker
 
     public static void Unpack()
     {
-        Log.Logger = new LoggerConfiguration().WriteTo.Console(theme: AnsiConsoleTheme.Literate).CreateLogger();
-
         ZlibHelper.Initialize();
         OodleHelper.Initialize();
 

--- a/CUE4Parse/Compression/OodleHelper.cs
+++ b/CUE4Parse/Compression/OodleHelper.cs
@@ -25,6 +25,8 @@ public class OodleException : ParserException
 
 public static class OodleHelper
 {
+    private static ILogger Log = Serilog.Log.ForContext(typeof(OodleHelper));
+    
     public const string OODLE_NAME_OLD = "oo2core_9_win64.dll";
     public const string OODLE_NAME_CURRENT = "oodle-data-shared.dll";
     public const string OODLE_NAME_LINUX = "liboodle-data-shared.so";

--- a/CUE4Parse/Compression/ZlibHelper.cs
+++ b/CUE4Parse/Compression/ZlibHelper.cs
@@ -24,6 +24,8 @@ public class ZlibException : ParserException
 
 public static class ZlibHelper
 {
+    private static readonly ILogger Log = Serilog.Log.ForContext(typeof(ZlibHelper));
+    
     public const string DOWNLOAD_URL = "https://github.com/NotOfficer/Zlib-ng.NET/releases/download/1.0.0/zlib-ng2.dll.gz";
     public const string DOWNLOAD_URL_LINUX = "https://github.com/NotOfficer/Zlib-ng.NET/releases/download/1.0.0/libz-ng.so.gz";
     public const string DLL_NAME = "zlib-ng2.dll";

--- a/CUE4Parse/FileProvider/AbstractFileProvider.cs
+++ b/CUE4Parse/FileProvider/AbstractFileProvider.cs
@@ -26,7 +26,6 @@ using CUE4Parse.UE4.Versions;
 using CUE4Parse.UE4.VirtualFileSystem;
 using CUE4Parse.Utils;
 using Newtonsoft.Json;
-using Serilog;
 using UE4Config.Parsing;
 
 namespace CUE4Parse.FileProvider
@@ -43,8 +42,6 @@ namespace CUE4Parse.FileProvider
 
     public abstract class AbstractFileProvider : IFileProvider
     {
-        protected static readonly ILogger Log = Serilog.Log.ForContext<IFileProvider>();
-
         public VersionContainer Versions { get; }
         public StringComparer PathComparer { get; }
         public StringComparison StringComparison { get; }

--- a/CUE4Parse/FileProvider/Objects/GameFile.cs
+++ b/CUE4Parse/FileProvider/Objects/GameFile.cs
@@ -15,6 +15,8 @@ namespace CUE4Parse.FileProvider.Objects;
 
 public abstract class GameFile
 {
+    private static readonly ILogger Log = Serilog.Log.ForContext<GameFile>();
+    
     public static readonly string[] UePackageExtensions = ["uasset", "umap"];
     public static readonly string[] UePackagePayloadExtensions = ["uexp", "ubulk", "uptnl"];
     public static readonly string[] UeKnownExtensions =

--- a/CUE4Parse/FileProvider/Vfs/AbstractVfsFileProvider.cs
+++ b/CUE4Parse/FileProvider/Vfs/AbstractVfsFileProvider.cs
@@ -45,11 +45,14 @@ using CUE4Parse.UE4.Versions;
 using CUE4Parse.UE4.VirtualFileSystem;
 using CUE4Parse.Utils;
 using OffiUtils;
+using Serilog;
 
 namespace CUE4Parse.FileProvider.Vfs
 {
     public abstract class AbstractVfsFileProvider : AbstractFileProvider, IVfsFileProvider
     {
+        private static readonly ILogger Log = Serilog.Log.ForContext<AbstractVfsFileProvider>();
+        
         protected readonly ConcurrentDictionary<IAesVfsReader, object?> _unloadedVfs = new ();
         public IReadOnlyCollection<IAesVfsReader> UnloadedVfs => (IReadOnlyCollection<IAesVfsReader>) _unloadedVfs.Keys;
 

--- a/CUE4Parse/GameTypes/Aion2/Objects/FAion2DataTableFile.cs
+++ b/CUE4Parse/GameTypes/Aion2/Objects/FAion2DataTableFile.cs
@@ -9,6 +9,8 @@ namespace CUE4Parse.GameTypes.Aion2.Objects;
 
 public class FAion2DataTableFile : FAion2DataFile
 {
+    private static readonly ILogger Log = Serilog.Log.ForContext<FAion2DataTableFile>();
+    
     public FAion2DataTableFile(GameFile file, IFileProvider provider)
     {
         var data = file.SafeRead();

--- a/CUE4Parse/GameTypes/Aion2/Objects/FAion2MapDataFile.cs
+++ b/CUE4Parse/GameTypes/Aion2/Objects/FAion2MapDataFile.cs
@@ -8,6 +8,8 @@ namespace CUE4Parse.GameTypes.Aion2.Objects;
 
 public class FAion2MapDataFile : FAion2DataFile
 {
+    private static readonly ILogger Log = Serilog.Log.ForContext<FAion2MapDataFile>();
+    
     public FAion2MapDataFile(GameFile file, IFileProvider provider)
     {
         var data = file.SafeRead();

--- a/CUE4Parse/GameTypes/AoC/Objects/FAoCDBCReader.cs
+++ b/CUE4Parse/GameTypes/AoC/Objects/FAoCDBCReader.cs
@@ -29,6 +29,8 @@ public struct FAoCDataChunk
 [JsonConverter(typeof(FAoCDBCReaderConverter))]
 public sealed class FAoCDBCReader : FAssetArchive
 {
+    private static readonly ILogger Log = Serilog.Log.ForContext<FAoCDBCReader>();
+    
     private Dictionary<int, string> NameMap = [];
     public FAoCDataChunk[] Chunks = [];
 

--- a/CUE4Parse/GameTypes/AshEchoes/FileProvider/AshEchoesDefaultFileProvider.cs
+++ b/CUE4Parse/GameTypes/AshEchoes/FileProvider/AshEchoesDefaultFileProvider.cs
@@ -18,12 +18,15 @@ using CUE4Parse.UE4.Versions;
 using CUE4Parse.UE4.VirtualFileSystem;
 using CUE4Parse.Utils;
 using GenericReader;
+using Serilog;
 using static CUE4Parse.Compression.Compression;
 
 namespace CUE4Parse.GameTypes.AshEchoes.FileProvider;
 
 public class AEDefaultFileProvider : DefaultFileProvider
 {
+    private static readonly ILogger Log = Serilog.Log.ForContext<AEDefaultFileProvider>();
+    
     public AEDefaultFileProvider(string directory, SearchOption searchOption, VersionContainer? versions = null,
         StringComparer? pathComparer = null) : base(directory, searchOption, versions, pathComparer)
     {

--- a/CUE4Parse/GameTypes/CrystalOfAtlan/Pak/CoAPakFileReader.cs
+++ b/CUE4Parse/GameTypes/CrystalOfAtlan/Pak/CoAPakFileReader.cs
@@ -11,11 +11,14 @@ using CUE4Parse.UE4.Objects.UObject;
 using CUE4Parse.UE4.Pak.Objects;
 using CUE4Parse.UE4.Readers;
 using GenericReader;
+using Serilog;
 
 namespace CUE4Parse.UE4.Pak;
 
 public static class CoAPlugins
 {
+    private static readonly ILogger Log = Serilog.Log.ForContext(typeof(CoAPlugins));
+    
     public static readonly byte[] returnbytes = [0x72, 0x65, 0x74, 0x75, 0x72, 0x6e];
     public static readonly Dictionary<string, string> CoAVirtualPaths = new(StringComparer.OrdinalIgnoreCase)
     {

--- a/CUE4Parse/GameTypes/FN/Assets/Exports/ULevelSaveRecord.cs
+++ b/CUE4Parse/GameTypes/FN/Assets/Exports/ULevelSaveRecord.cs
@@ -87,6 +87,8 @@ namespace CUE4Parse.GameTypes.FN.Assets.Exports
     [StructFallback]
     public class FActorTemplateRecord
     {
+        private static readonly ILogger Log = Serilog.Log.ForContext<FActorTemplateRecord>();
+        
         public ulong ID;
         public FSoftObjectPath ActorClass;
         public FActorComponentRecord[] ActorComponents;
@@ -179,6 +181,8 @@ namespace CUE4Parse.GameTypes.FN.Assets.Exports
 
     public class FActorComponentRecord
     {
+        private static readonly ILogger Log = Serilog.Log.ForContext<FActorComponentRecord>();
+        
         public FName ComponentName;
         public FSoftObjectPath ComponentClass; // UClass
         public byte[]? ComponentData;
@@ -329,6 +333,8 @@ namespace CUE4Parse.GameTypes.FN.Assets.Exports
 
     public class ULevelSaveRecord : UObject
     {
+        private static readonly ILogger Log = Serilog.Log.ForContext<ULevelSaveRecord>();
+        
         public FName PackageName;
         public ELevelSaveRecordVersion SaveVersion;
         public bool bCompressed;

--- a/CUE4Parse/GameTypes/HonorOfKings/FileProvider/HoKWorldDefaultFileProvider.cs
+++ b/CUE4Parse/GameTypes/HonorOfKings/FileProvider/HoKWorldDefaultFileProvider.cs
@@ -8,11 +8,14 @@ using CUE4Parse.GameTypes.HonorOfKings.Vfs;
 using CUE4Parse.GameTypes.HonorOfKings.Vfs.Objects;
 using CUE4Parse.UE4.Versions;
 using CUE4Parse.Utils;
+using Serilog;
 
 namespace CUE4Parse.GameTypes.HonorOfKings.FileProvider;
 
 public class HoKWDefaultFileProvider : DefaultFileProvider
 {
+    private static readonly ILogger Log = Serilog.Log.ForContext<HoKWDefaultFileProvider>();
+    
     public static string GeneratedIndexFolder;
 
     public HoKWDefaultFileProvider(string directory, SearchOption searchOption, VersionContainer? versions = null,

--- a/CUE4Parse/GameTypes/HonorOfKings/Lua/NGRLua.cs
+++ b/CUE4Parse/GameTypes/HonorOfKings/Lua/NGRLua.cs
@@ -47,6 +47,8 @@ public readonly struct Chunk(FNGRLuaArchive Ar, int chunkSize)
 
 public class NGRLuaReader
 {
+    private static readonly ILogger Log = Serilog.Log.ForContext<NGRLuaReader>();
+    
     private const uint NGR_LUA_MAGIC = 0xFADEFACE;
 
     public FadeFaceHeader Header;

--- a/CUE4Parse/GameTypes/HonorOfKings/Vfs/HoKdbFileReader.cs
+++ b/CUE4Parse/GameTypes/HonorOfKings/Vfs/HoKdbFileReader.cs
@@ -18,11 +18,14 @@ using CUE4Parse.UE4.Readers;
 using CUE4Parse.UE4.Versions;
 using CUE4Parse.UE4.VirtualFileSystem;
 using GenericReader;
+using Serilog;
 
 namespace CUE4Parse.GameTypes.HonorOfKings.Vfs;
 
 public sealed class HoKdbFileReader : AbstractAesVfsReader
 {
+    private static readonly ILogger Log = Serilog.Log.ForContext<HoKdbFileReader>();
+    
     public static readonly ConcurrentDictionary<ulong, string> HashMap = [];
     private static readonly ConcurrentDictionary<ulong, string> _indexFiles = [];
     private readonly IReadOnlyList<HoKdbContainerStream> _containerStreams;

--- a/CUE4Parse/GameTypes/LegoBatman/Assets/UWubDialogueEvent.cs
+++ b/CUE4Parse/GameTypes/LegoBatman/Assets/UWubDialogueEvent.cs
@@ -11,6 +11,8 @@ namespace CUE4Parse.GameTypes.LegoBatman.Assets;
 
 public class UWubDialogueEvent : UObject
 {
+    private static readonly ILogger Log = Serilog.Log.ForContext<UWubDialogueEvent>();
+    
     public FWubStruct2 Sequence;
     public HashSet<FName> Wems = [];
 

--- a/CUE4Parse/GameTypes/MK1/Assets/Objects/MK1Structs.cs
+++ b/CUE4Parse/GameTypes/MK1/Assets/Objects/MK1Structs.cs
@@ -1,7 +1,5 @@
-using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Linq;
 using CUE4Parse.UE4;
 using CUE4Parse.UE4.Assets.Exports.Animation;
 using CUE4Parse.UE4.Assets.Exports.Engine;
@@ -88,6 +86,8 @@ public class FTimelinePredicateState(FAssetArchive Ar) : IUStruct
 
 public class FCompiledTimelinePredicate : IUStruct
 {
+    private static readonly ILogger Log = Serilog.Log.ForContext<FCompiledTimelinePredicate>();
+    
     public byte[] Unknown;
     public object[] Parameters;
 

--- a/CUE4Parse/GameTypes/OctopathTraveler/Exports/UBinaryAsset.cs
+++ b/CUE4Parse/GameTypes/OctopathTraveler/Exports/UBinaryAsset.cs
@@ -17,6 +17,8 @@ namespace CUE4Parse.GameTypes.OctopathTraveler.Exports;
 
 public class UBinaryAsset : UObject
 {
+    private static readonly ILogger Log = Serilog.Log.ForContext<UBinaryAsset>();
+    
     public override void Deserialize(FAssetArchive Ar, long validPos)
     {
         base.Deserialize(Ar, validPos);

--- a/CUE4Parse/GameTypes/OtherGames/Objects/Palia.cs
+++ b/CUE4Parse/GameTypes/OtherGames/Objects/Palia.cs
@@ -42,6 +42,8 @@ public class UVAL_PremiumItemAsset : UPrimaryDataAsset
 
 public class FVAL_CharacterCustomizationVariantOptionsArray : IUStruct
 {
+    private static readonly ILogger Log = Serilog.Log.ForContext<FVAL_CharacterCustomizationVariantOptionsArray>();
+    
     public FPackageIndex OptionStruct;
     public IUStruct[] Options = [];
     public FVAL_CharacterCustomizationVariantOptionsArray(FAssetArchive Ar)

--- a/CUE4Parse/GameTypes/OtherGames/Objects/Vindictus.cs
+++ b/CUE4Parse/GameTypes/OtherGames/Objects/Vindictus.cs
@@ -8,6 +8,8 @@ namespace CUE4Parse.GameTypes.OtherGames.Objects;
 
 public struct FAnyValue : IUStruct
 {
+    private static readonly ILogger Log = Serilog.Log.ForContext<FAnyValue>();
+    
     public readonly FStructFallback? NonConstStruct;
 
     public FAnyValue(FAssetArchive Ar)

--- a/CUE4Parse/GameTypes/OuterWorlds2/Properties/FOW2FPropertyTag.cs
+++ b/CUE4Parse/GameTypes/OuterWorlds2/Properties/FOW2FPropertyTag.cs
@@ -24,6 +24,8 @@ public class FOW2ObjectProperty : ObjectProperty
 
 public class FOW2FPropertyTag : FPropertyTag
 {
+    private static readonly ILogger Log = Serilog.Log.ForContext<FOW2FPropertyTag>();
+    
     public FPropertryDataObjectContainer Objects;
     public bool bHasVersion;
     public bool bIsDefault;

--- a/CUE4Parse/GameTypes/TQ2/Objects/TQ2Structs.cs
+++ b/CUE4Parse/GameTypes/TQ2/Objects/TQ2Structs.cs
@@ -225,6 +225,8 @@ public struct FArticyId(FAssetArchive Ar) : IUStruct
 
 public class FGrimInstancedObjectPtr : IUStruct
 {
+    private static readonly ILogger Log = Serilog.Log.ForContext<FGrimInstancedObjectPtr>();
+    
     public int Type;
     public int Index;
     public FPackageIndex StructType;

--- a/CUE4Parse/UE4/AssetRegistry/FAssetRegistryState.cs
+++ b/CUE4Parse/UE4/AssetRegistry/FAssetRegistryState.cs
@@ -11,6 +11,8 @@ namespace CUE4Parse.UE4.AssetRegistry;
 [JsonConverter(typeof(FAssetRegistryStateConverter))]
 public class FAssetRegistryState
 {
+    private static readonly ILogger Log = Serilog.Log.ForContext<FAssetRegistryState>();
+    
     public FAssetData[] PreallocatedAssetDataBuffers;
     public FDependsNode[] PreallocatedDependsNodeDataBuffers;
     public FAssetPackageData[] PreallocatedPackageDataBuffers;

--- a/CUE4Parse/UE4/AssetRegistry/FPartialAssetRegistryState.cs
+++ b/CUE4Parse/UE4/AssetRegistry/FPartialAssetRegistryState.cs
@@ -7,6 +7,8 @@ namespace CUE4Parse.UE4.AssetRegistry;
 
 public class FPartialAssetRegistryState
 {
+    private static readonly ILogger Log = Serilog.Log.ForContext<FPartialAssetRegistryState>();
+    
     public FPartialAssetData[] PreallocatedAssetDataBuffers = [];
 
     public FPartialAssetRegistryState() { }

--- a/CUE4Parse/UE4/Assets/AbstractUePackage.cs
+++ b/CUE4Parse/UE4/Assets/AbstractUePackage.cs
@@ -17,6 +17,8 @@ namespace CUE4Parse.UE4.Assets;
 [JsonConverter(typeof(PackageConverter))]
 public abstract class AbstractUePackage : UObject, IPackage
 {
+    private static readonly ILogger Log = Serilog.Log.ForContext<AbstractUePackage>();
+    
     public IFileProvider? Provider { get; }
     public TypeMappings? Mappings => Provider?.MappingsForGame;
 

--- a/CUE4Parse/UE4/Assets/Exports/Animation/UAnimSequence.cs
+++ b/CUE4Parse/UE4/Assets/Exports/Animation/UAnimSequence.cs
@@ -18,6 +18,8 @@ namespace CUE4Parse.UE4.Assets.Exports.Animation
 {
     public class UAnimSequence : UAnimSequenceBase
     {
+        private static readonly ILogger Log = Serilog.Log.ForContext<UAnimSequence>();
+        
         public int NumFrames;
         public FTrackToSkeletonMap[]? TrackToSkeletonMapTable; // used for raw data
         public FRawAnimSequenceTrack[] RawAnimationData;

--- a/CUE4Parse/UE4/Assets/Exports/Animation/USkeleton.cs
+++ b/CUE4Parse/UE4/Assets/Exports/Animation/USkeleton.cs
@@ -14,6 +14,8 @@ namespace CUE4Parse.UE4.Assets.Exports.Animation
 {
     public class USkeleton : UObject
     {
+        private static readonly ILogger Log = Serilog.Log.ForContext<UAnimSequence>();
+        
         public EBoneTranslationRetargetingMode[] BoneTree { get; private set; }
         public FReferenceSkeleton ReferenceSkeleton { get; private set; }
         public FGuid Guid { get; private set; }

--- a/CUE4Parse/UE4/Assets/Exports/Engine/UCurveTable.cs
+++ b/CUE4Parse/UE4/Assets/Exports/Engine/UCurveTable.cs
@@ -11,6 +11,8 @@ namespace CUE4Parse.UE4.Assets.Exports.Engine
 {
     public class UCurveTable : UObject
     {
+        private static readonly ILogger Log = Serilog.Log.ForContext<UCurveTable>();
+        
         public Dictionary<FName, FStructFallback> RowMap { get; private set; } // FStructFallback is FRealCurve aka FSimpleCurve if CurveTableMode is SimpleCurves else FRichCurve
         public ECurveTableMode CurveTableMode { get; private set; }
 

--- a/CUE4Parse/UE4/Assets/Exports/Engine/UDataTable.cs
+++ b/CUE4Parse/UE4/Assets/Exports/Engine/UDataTable.cs
@@ -11,6 +11,8 @@ namespace CUE4Parse.UE4.Assets.Exports.Engine;
 
 public class UDataTable : UObject
 {
+    private static readonly ILogger Log = Serilog.Log.ForContext<UDataTable>();
+    
     public Dictionary<FName, FStructFallback> RowMap { get; protected set; }
     public string? RowStructName { get; protected set; } // Set by inheritor or during deserialization
 

--- a/CUE4Parse/UE4/Assets/Exports/Material/MaterialResourceTypes.cs
+++ b/CUE4Parse/UE4/Assets/Exports/Material/MaterialResourceTypes.cs
@@ -21,6 +21,8 @@ public class FMaterialResource : FMaterial;
 
 public class FMaterial
 {
+    private static readonly ILogger Log = Serilog.Log.ForContext<FMaterial>();
+    
     public FMaterialShaderMap? LoadedShaderMap;
 
     public void DeserializeInlineShaderMap(FMaterialResourceProxyReader Ar)

--- a/CUE4Parse/UE4/Assets/Exports/Material/UMaterial.cs
+++ b/CUE4Parse/UE4/Assets/Exports/Material/UMaterial.cs
@@ -15,6 +15,8 @@ namespace CUE4Parse.UE4.Assets.Exports.Material;
 
 public class UMaterial : UMaterialInterface
 {
+    private static readonly ILogger Log = Serilog.Log.ForContext<UMaterial>();
+    
     public bool TwoSided { get; private set; }
     public bool bDisableDepthTest { get; private set; }
     public bool bIsMasked { get; private set; }

--- a/CUE4Parse/UE4/Assets/Exports/Material/UMaterialInstance.cs
+++ b/CUE4Parse/UE4/Assets/Exports/Material/UMaterialInstance.cs
@@ -17,6 +17,8 @@ public class UMaterialInstanceDynamic: UMaterialInstance;
 
 public class UMaterialInstance : UMaterialInterface
 {
+    private static readonly ILogger Log = Serilog.Log.ForContext<UMaterialInstance>();
+    
     private ResolvedObject? _parent;
     private bool bHasNonUPropertyStaticParameters = false;
     public UUnrealMaterial? Parent => _parent?.Load<UUnrealMaterial>();

--- a/CUE4Parse/UE4/Assets/Exports/Nanite/NaniteResources.cs
+++ b/CUE4Parse/UE4/Assets/Exports/Nanite/NaniteResources.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Buffers;
 using System.Collections.Generic;
-using System.Linq;
 using CUE4Parse.UE4.Assets.Objects;
 using CUE4Parse.UE4.Assets.Readers;
 using CUE4Parse.UE4.Objects.Core.Math;
@@ -16,6 +15,8 @@ namespace CUE4Parse.UE4.Assets.Exports.Nanite;
 
 public class FNaniteResources
 {
+    private static readonly ILogger Log = Serilog.Log.ForContext<FNaniteResources>();
+    
     // Persistent State
     public FByteBulkData? StreamablePages = null; // Remaining pages are streamed on demand.
     [JsonIgnore] public ushort[] ImposterAtlas = [];

--- a/CUE4Parse/UE4/Assets/Exports/NavigationSystem/ARecastNavMesh.cs
+++ b/CUE4Parse/UE4/Assets/Exports/NavigationSystem/ARecastNavMesh.cs
@@ -7,6 +7,8 @@ namespace CUE4Parse.UE4.Assets.Exports.NavigationSystem;
 
 public class ARecastNavMesh : ANavigationData
 {
+    private static readonly ILogger Log = Serilog.Log.ForContext<ARecastNavMesh>();
+    
     public float AgentHeight;
     public float AgentRadius;
     public FNavMeshResolutionParam[] NavMeshResolutionParams; 

--- a/CUE4Parse/UE4/Assets/Exports/NavigationSystem/URecastNavMeshDataChunk.cs
+++ b/CUE4Parse/UE4/Assets/Exports/NavigationSystem/URecastNavMeshDataChunk.cs
@@ -1,15 +1,17 @@
 using CUE4Parse.UE4.Assets.Readers;
 using CUE4Parse.UE4.Versions;
 using Newtonsoft.Json;
-using Serilog;
 using CUE4Parse.UE4.Assets.Exports.NavigationSystem.Detour;
 using CUE4Parse.UE4.Assets.Exports.NavigationSystem;
 using CUE4Parse.UE4.Readers;
+using Serilog;
 
 namespace CUE4Parse.UE4.Objects.NavigationSystem.NavMesh;
 
 public class URecastNavMeshDataChunk : Assets.Exports.UObject
 {
+    private static readonly ILogger Log = Serilog.Log.ForContext<URecastNavMeshDataChunk>();
+    
     public ENavMeshVersion NavMeshVersion;
     public FRecastTileData[] Tiles = [];
 

--- a/CUE4Parse/UE4/Assets/Exports/Rig/UDNAAsset.cs
+++ b/CUE4Parse/UE4/Assets/Exports/Rig/UDNAAsset.cs
@@ -12,6 +12,8 @@ namespace CUE4Parse.UE4.Assets.Exports.Rig;
 
 public class UDNAAsset : UObject
 {
+    private static readonly ILogger Log = Serilog.Log.ForContext<UDNAAsset>();
+    
     public DNAVersion Version;
     public DNAVersion LayerVersion;
     public Dictionary<string, IRawBase> Sections;

--- a/CUE4Parse/UE4/Assets/Exports/SkeletalMesh/FSkelMeshSection.cs
+++ b/CUE4Parse/UE4/Assets/Exports/SkeletalMesh/FSkelMeshSection.cs
@@ -22,6 +22,8 @@ public enum ESkinVertexColorChannel : byte
 [JsonConverter(typeof(FSkelMeshSectionConverter))]
 public class FSkelMeshSection
 {
+    private static readonly ILogger Log = Serilog.Log.ForContext<FSkelMeshSection>();
+    
     public short MaterialIndex;
     public int BaseIndex;
     public int NumTriangles;

--- a/CUE4Parse/UE4/Assets/Exports/Texture/UTexture.cs
+++ b/CUE4Parse/UE4/Assets/Exports/Texture/UTexture.cs
@@ -19,6 +19,8 @@ public class UBinkMediaTexture : UTexture;
 
 public abstract class UTexture : UUnrealMaterial, IAssetUserData
 {
+    private static readonly ILogger Log = Serilog.Log.ForContext<UTexture>();
+    
     public FGuid LightingGuid { get; private set; }
     public TextureCompressionSettings CompressionSettings { get; private set; }
     public TextureGroup LODGroup { get; private set; }

--- a/CUE4Parse/UE4/Assets/Exports/Texture/UTexture2D.cs
+++ b/CUE4Parse/UE4/Assets/Exports/Texture/UTexture2D.cs
@@ -10,6 +10,8 @@ namespace CUE4Parse.UE4.Assets.Exports.Texture;
 
 public class UTexture2D : UTexture
 {
+    private static readonly ILogger Log = Serilog.Log.ForContext<UTexture2D>();
+    
     public FIntPoint ImportedSize { get; private set; }
     public TextureAddress AddressX { get; private set; }
     public TextureAddress AddressY { get; private set; }

--- a/CUE4Parse/UE4/Assets/Exports/UObject.cs
+++ b/CUE4Parse/UE4/Assets/Exports/UObject.cs
@@ -100,6 +100,8 @@ public abstract class AbstractPropertyHolder : IPropertyHolder
 [SkipObjectRegistration]
 public class UObject : AbstractPropertyHolder
 {
+    private static readonly ILogger Log = Serilog.Log.ForContext<UObject>();
+    
     public string Name { get; set; } = null!;
     public ResolvedObject? Class;
     public ResolvedObject? Outer;

--- a/CUE4Parse/UE4/Assets/Exports/Wwise/FWwisePackagedFile.cs
+++ b/CUE4Parse/UE4/Assets/Exports/Wwise/FWwisePackagedFile.cs
@@ -11,6 +11,8 @@ namespace CUE4Parse.UE4.Assets.Exports.Wwise;
 [JsonConverter(typeof(FWwisePackagedFileConverter))]
 public class FWwisePackagedFile : FStructFallback
 {
+    private static readonly ILogger Log = Serilog.Log.ForContext<FWwisePackagedFile>();
+    
     public EWwisePackagingStrategy PackagingStrategy;
     public FName PathName;
     public FName ModularGameplayName;

--- a/CUE4Parse/UE4/Assets/IoPackage.cs
+++ b/CUE4Parse/UE4/Assets/IoPackage.cs
@@ -20,6 +20,8 @@ namespace CUE4Parse.UE4.Assets;
 [SkipObjectRegistration]
 public sealed class IoPackage : AbstractUePackage
 {
+    private static readonly ILogger Log = Serilog.Log.ForContext<IoPackage>();
+    
     private readonly IoGlobalData _globalData;
 
     public override FPackageFileSummary Summary { get; }

--- a/CUE4Parse/UE4/Assets/Objects/FByteBulkData.cs
+++ b/CUE4Parse/UE4/Assets/Objects/FByteBulkData.cs
@@ -27,6 +27,8 @@ public sealed class FByteArrayData : TBulkData<byte>
 [JsonConverter(typeof(FByteBulkDataConverter))]
 public sealed class FByteBulkData : TBulkData<byte>
 {
+    private static readonly ILogger Log = Serilog.Log.ForContext<FByteBulkData>();
+    
     public FByteBulkData(FAssetArchive Ar) : base(Ar) { }
 
     /// <summary>

--- a/CUE4Parse/UE4/Assets/Objects/FEditorBulkData.cs
+++ b/CUE4Parse/UE4/Assets/Objects/FEditorBulkData.cs
@@ -40,6 +40,8 @@ public enum EFlags
 
 public class FEditorBulkData
 {
+    private static readonly ILogger Log = Serilog.Log.ForContext<FEditorBulkData>();
+    
     public EFlags Flags { get; set; }
     public FGuid BulkDataId { get; set; }
     public FSHAHash PayloadContentId { get; set; }

--- a/CUE4Parse/UE4/Assets/Objects/FInstancedStruct.cs
+++ b/CUE4Parse/UE4/Assets/Objects/FInstancedStruct.cs
@@ -12,6 +12,8 @@ namespace CUE4Parse.UE4.Assets.Objects;
 [JsonConverter(typeof(FInstancedStructConverter))]
 public class FInstancedStruct : IUStruct
 {
+    private static readonly ILogger Log = Serilog.Log.ForContext<FEditorBulkData>();
+    
     public FStructFallback NonConstStruct => NonConstIUSturct as FStructFallback ?? new FStructFallback();
     public readonly IUStruct? NonConstIUSturct;
     public readonly string? StringData;

--- a/CUE4Parse/UE4/Assets/Objects/FPropertyTag.cs
+++ b/CUE4Parse/UE4/Assets/Objects/FPropertyTag.cs
@@ -79,6 +79,8 @@ public static class FPropertyTypeNameUtils
 
 public class FPropertyTag
 {
+    private static readonly ILogger Log = Serilog.Log.ForContext<FPropertyTag>();
+    
     public FName Name;
     public FName PropertyType;
     public int Size;

--- a/CUE4Parse/UE4/Assets/Objects/FStructFallback.cs
+++ b/CUE4Parse/UE4/Assets/Objects/FStructFallback.cs
@@ -14,6 +14,8 @@ namespace CUE4Parse.UE4.Assets.Objects;
 [SkipObjectRegistration]
 public class FStructFallback : AbstractPropertyHolder, IUStruct
 {
+    private static readonly ILogger Log = Serilog.Log.ForContext<FStructFallback>();
+
     public FStructFallback() => Properties = [];
 
     public FStructFallback(List<FPropertyTag> properties) => Properties = properties;

--- a/CUE4Parse/UE4/Assets/Objects/Properties/FPropertyTagType.cs
+++ b/CUE4Parse/UE4/Assets/Objects/Properties/FPropertyTagType.cs
@@ -39,6 +39,8 @@ public abstract class FPropertyTagType<T> : FPropertyTagType
 [JsonConverter(typeof(FPropertyTagTypeConverter))]
 public abstract class FPropertyTagType
 {
+    private static readonly ILogger Log = Serilog.Log.ForContext<FPropertyTagType>();
+    
     public abstract object? GenericValue { get; }
     public object? GetValue(Type type)
     {

--- a/CUE4Parse/UE4/Assets/Objects/TBulkData.cs
+++ b/CUE4Parse/UE4/Assets/Objects/TBulkData.cs
@@ -18,6 +18,8 @@ namespace CUE4Parse.UE4.Assets.Objects;
 [JsonConverter(typeof(TBulkDataConverter))]
 public abstract class TBulkData<T> where T: struct
 {
+    private static readonly ILogger Log = Serilog.Log.ForContext<TBulkData<T>>();
+    
     public FByteBulkDataHeader Header { get; init; }
     public EBulkDataFlags BulkDataFlags => Header.BulkDataFlags;
 

--- a/CUE4Parse/UE4/Assets/Objects/UScriptArray.cs
+++ b/CUE4Parse/UE4/Assets/Objects/UScriptArray.cs
@@ -13,6 +13,8 @@ namespace CUE4Parse.UE4.Assets.Objects;
 [JsonConverter(typeof(UScriptArrayConverter))]
 public class UScriptArray
 {
+    private static readonly ILogger Log = Serilog.Log.ForContext<UScriptArray>();
+    
     public readonly string InnerType;
     public readonly FPropertyTagData? InnerTagData;
     public readonly List<FPropertyTagType> Properties;

--- a/CUE4Parse/UE4/Assets/Objects/UScriptSet.cs
+++ b/CUE4Parse/UE4/Assets/Objects/UScriptSet.cs
@@ -13,6 +13,8 @@ namespace CUE4Parse.UE4.Assets.Objects;
 [JsonConverter(typeof(UScriptSetConverter))]
 public class UScriptSet
 {
+    private static readonly ILogger Log = Serilog.Log.ForContext<UScriptSet>();
+    
     public readonly List<FPropertyTagType> Properties;
 
     public UScriptSet() => Properties = [];

--- a/CUE4Parse/UE4/Assets/Package.cs
+++ b/CUE4Parse/UE4/Assets/Package.cs
@@ -20,6 +20,8 @@ namespace CUE4Parse.UE4.Assets
     [SkipObjectRegistration]
     public sealed class Package : AbstractUePackage
     {
+        private static readonly ILogger Log = Serilog.Log.ForContext<Package>();
+        
         public override FPackageFileSummary Summary { get; }
         public override FNameEntrySerialized[] NameMap { get; }
         public override int ImportMapLength => ImportMap.Length;

--- a/CUE4Parse/UE4/Assets/Readers/FAssetArchive.cs
+++ b/CUE4Parse/UE4/Assets/Readers/FAssetArchive.cs
@@ -18,6 +18,8 @@ namespace CUE4Parse.UE4.Assets.Readers
 {
     public class FAssetArchive : FArchive
     {
+        private static readonly ILogger Log = Serilog.Log.ForContext<FAssetArchive>();
+        
         private readonly Dictionary<PayloadType, Func<FByteBulkDataHeader?, FAssetArchive?>> _payloads;
         private FArchive _baseArchive;
 

--- a/CUE4Parse/UE4/CriWare/CriWareProvider.cs
+++ b/CUE4Parse/UE4/CriWare/CriWareProvider.cs
@@ -40,6 +40,8 @@ public class CriWareExtractedSound
 /// </summary>
 public class CriWareProvider
 {
+    private static readonly ILogger Log = Serilog.Log.ForContext<CriWareProvider>();
+    
     private readonly record struct AwbLocation(string Path, bool InProvider);
     private Dictionary<string, AwbLocation> _streamingAwbLookup = [];
 

--- a/CUE4Parse/UE4/CriWare/Readers/AcbReader.cs
+++ b/CUE4Parse/UE4/CriWare/Readers/AcbReader.cs
@@ -9,6 +9,8 @@ namespace CUE4Parse.UE4.CriWare.Readers;
 [JsonConverter(typeof(AcbReaderConverter))]
 public sealed class AcbReader : IDisposable
 {
+    private static readonly ILogger Log = Serilog.Log.ForContext<AcbReader>();
+    
     private readonly Stream _outerStream;
     private readonly long _offset;
     private readonly uint _awbOffset;

--- a/CUE4Parse/UE4/FMod/FModProvider.cs
+++ b/CUE4Parse/UE4/FMod/FModProvider.cs
@@ -29,6 +29,8 @@ public class FModExtractedSound
 
 public class FModProvider
 {
+    private static readonly ILogger Log = Serilog.Log.ForContext<FModProvider>();
+    
     private Dictionary<FModGuid, List<FmodSample>> _resolvedEventsCache = [];
     private Dictionary<FModGuid, bool> _eventResolutionStatus = [];
     private Dictionary<FModGuid, FModGuid> _eventToReaderMap = [];

--- a/CUE4Parse/UE4/FMod/FModReader.cs
+++ b/CUE4Parse/UE4/FMod/FModReader.cs
@@ -21,6 +21,8 @@ namespace CUE4Parse.UE4.FMod;
 [JsonConverter(typeof(FModConverter))]
 public class FModReader
 {
+    private static readonly ILogger Log = Serilog.Log.ForContext<FModReader>();
+    
     public readonly string BankName;
     public static int Version => FormatInfo.FileVersion;
     public static FFormatInfo FormatInfo;

--- a/CUE4Parse/UE4/FMod/Fsb5Decryption.cs
+++ b/CUE4Parse/UE4/FMod/Fsb5Decryption.cs
@@ -66,6 +66,8 @@ namespace CUE4Parse.UE4.FMod;
 /// </summary>
 public class Fsb5Decryption
 {
+    private static readonly ILogger Log = Serilog.Log.ForContext<Fsb5Decryption>();
+    
     private static readonly string FSB5Header = "FSB5";
     private static readonly byte[] ReverseBitsTable =
     [

--- a/CUE4Parse/UE4/FMod/Metadata/FFormatInfo.cs
+++ b/CUE4Parse/UE4/FMod/Metadata/FFormatInfo.cs
@@ -6,6 +6,8 @@ namespace CUE4Parse.UE4.FMod.Metadata;
 
 public readonly struct FFormatInfo
 {
+    private static readonly ILogger Log = Serilog.Log.ForContext<FFormatInfo>();
+    
     public readonly int FileVersion;
     public readonly int CompatVersion;
 

--- a/CUE4Parse/UE4/FMod/Nodes/ModulatorNode.cs
+++ b/CUE4Parse/UE4/FMod/Nodes/ModulatorNode.cs
@@ -9,6 +9,8 @@ namespace CUE4Parse.UE4.FMod.Nodes;
 
 public class ModulatorNode
 {
+    private static readonly ILogger Log = Serilog.Log.ForContext<ModulatorNode>();
+    
     [JsonIgnore] public readonly FModGuid BaseGuid;
     public readonly FModGuid OwnerGuid;
     public readonly int PropertyIndex;

--- a/CUE4Parse/UE4/FMod/Nodes/SoundDataNode.cs
+++ b/CUE4Parse/UE4/FMod/Nodes/SoundDataNode.cs
@@ -10,6 +10,8 @@ namespace CUE4Parse.UE4.FMod.Nodes;
 
 public class SoundDataNode
 {
+    private static readonly ILogger Log = Serilog.Log.ForContext<SoundDataNode>();
+    
     public readonly FmodSoundBank? SoundBank;
 
     public SoundDataNode(BinaryReader Ar, long nodeStart, uint size, int soundDataIndex)

--- a/CUE4Parse/UE4/FMod/Utils/EventNodesResolver.cs
+++ b/CUE4Parse/UE4/FMod/Utils/EventNodesResolver.cs
@@ -11,6 +11,8 @@ namespace CUE4Parse.UE4.FMod.Utils;
 
 public static class EventNodesResolver
 {
+    private static readonly ILogger Log = Serilog.Log.ForContext(typeof(EventNodesResolver));
+    
     public static Dictionary<FModGuid, List<FmodSample>> TryResolveAudioEvents(FModReader reader, out bool allWaveformsResolved)
     {
         var result = new Dictionary<FModGuid, List<FmodSample>>();

--- a/CUE4Parse/UE4/IO/IoStoreReader.cs
+++ b/CUE4Parse/UE4/IO/IoStoreReader.cs
@@ -18,11 +18,14 @@ using CUE4Parse.UE4.VirtualFileSystem;
 using CUE4Parse.Utils;
 using GenericReader;
 using OffiUtils;
+using Serilog;
 
 namespace CUE4Parse.UE4.IO;
 
 public partial class IoStoreReader : AbstractAesVfsReader
 {
+    private static readonly ILogger Log = Serilog.Log.ForContext<IoStoreReader>();
+    
     public readonly IReadOnlyList<FArchive> ContainerStreams;
 
     public readonly FIoStoreTocResource TocResource;

--- a/CUE4Parse/UE4/IO/Objects/FIoStoreTocResource.cs
+++ b/CUE4Parse/UE4/IO/Objects/FIoStoreTocResource.cs
@@ -20,6 +20,8 @@ namespace CUE4Parse.UE4.IO.Objects
 
     public class FIoStoreTocResource
     {
+        private static readonly ILogger Log = Serilog.Log.ForContext<FIoStoreTocResource>();
+        
         public readonly FIoStoreTocHeader Header;
         public readonly FIoChunkId[] ChunkIds;
         public readonly FIoOffsetAndLength[] ChunkOffsetLengths;

--- a/CUE4Parse/UE4/Localization/FTextLocalizationMetaDataResource.cs
+++ b/CUE4Parse/UE4/Localization/FTextLocalizationMetaDataResource.cs
@@ -10,6 +10,8 @@ namespace CUE4Parse.UE4.Localization
     [JsonConverter(typeof(FTextLocalizationMetaDataResourceConverter))]
     public class FTextLocalizationMetaDataResource
     {
+        private static readonly ILogger Log = Serilog.Log.ForContext<FTextLocalizationMetaDataResource>();
+        
         private readonly FGuid _locMetaMagic = new (0xA14CEE4Fu, 0x83554868u, 0xBD464C6Cu, 0x7C50DA70u);
         public readonly string NativeCulture;
         public readonly string NativeLocRes;

--- a/CUE4Parse/UE4/Localization/FTextLocalizationResource.cs
+++ b/CUE4Parse/UE4/Localization/FTextLocalizationResource.cs
@@ -16,6 +16,8 @@ namespace CUE4Parse.UE4.Localization;
 [JsonConverter(typeof(FTextLocalizationResourceConverter))]
 public class FTextLocalizationResource
 {
+    private static readonly ILogger Log = Serilog.Log.ForContext<FTextLocalizationResource>();
+    
     private readonly FGuid _locResMagic = new (0x7574140Eu, 0xFC034A67u, 0x9D90154Au, 0x1B7F37C3u);
     public readonly Dictionary<FTextKey, Dictionary<FTextKey, FEntry>> Entries = [];
 

--- a/CUE4Parse/UE4/Lua/unluac/Unluac.cs
+++ b/CUE4Parse/UE4/Lua/unluac/Unluac.cs
@@ -6,6 +6,8 @@ namespace CUE4Parse.UE4.Lua.unluac;
 
 public class Unluac : IDisposable
 {
+    private static readonly ILogger Log = Serilog.Log.ForContext<Unluac>();
+    
     private nint Handle { get; set; }
     private readonly unluac_create_isolate _createIsolate;
     private readonly unluac_tear_down_isolate _tearDownIsolate;

--- a/CUE4Parse/UE4/Lua/unluac/UnluacHelper.cs
+++ b/CUE4Parse/UE4/Lua/unluac/UnluacHelper.cs
@@ -13,6 +13,8 @@ namespace CUE4Parse.UE4.Lua.unluac;
 
 public static class UnluacHelper
 {
+    private static readonly ILogger Log = Serilog.Log.ForContext(typeof(UnluacHelper));
+    
     public const uint LuaMagic = 0x61754c1B;
     private const string _currentVersion = "1.0.0";
 

--- a/CUE4Parse/UE4/Objects/ControlRig/FControlRigOverrideValue.cs
+++ b/CUE4Parse/UE4/Objects/ControlRig/FControlRigOverrideValue.cs
@@ -11,6 +11,8 @@ namespace CUE4Parse.UE4.Objects.ControlRig;
 
 public class FControlRigOverrideValue
 {
+    private static readonly ILogger Log = Serilog.Log.ForContext<FControlRigOverrideValue>();
+    
     public FName SubjectKey; // TOptional
     public FPropertyInfo[] Properties;
     public long OffsetForData;

--- a/CUE4Parse/UE4/Objects/GameplayTags/FGameplayTagContainer.cs
+++ b/CUE4Parse/UE4/Objects/GameplayTags/FGameplayTagContainer.cs
@@ -197,6 +197,8 @@ public enum EGameplayTagQueryExprType
 
 public class FQueryEvaluator
 {
+    private static readonly ILogger Log = Serilog.Log.ForContext<FQueryEvaluator>();
+    
     private readonly FGameplayTagQuery Query;
     private int CurStreamIdx;
     private EGameplayTagQueryStreamVersion Version;

--- a/CUE4Parse/UE4/Objects/RigVM/FRigVMByteCode.cs
+++ b/CUE4Parse/UE4/Objects/RigVM/FRigVMByteCode.cs
@@ -11,6 +11,8 @@ namespace CUE4Parse.UE4.Objects.RigVM;
 
 public class FRigVMByteCode
 {
+    private static readonly ILogger Log = Serilog.Log.ForContext<FRigVMByteCode>();
+    
     public List<IRigInstruction> Instructions = [];
     public string[] Entries = [];
     public FRigVMBranchInfo[] BranchInfos = [];

--- a/CUE4Parse/UE4/Objects/UObject/BlueprintDecompiler/BlueprintDecompilerUtils.cs
+++ b/CUE4Parse/UE4/Objects/UObject/BlueprintDecompiler/BlueprintDecompilerUtils.cs
@@ -21,6 +21,8 @@ namespace CUE4Parse.UE4.Objects.UObject.BlueprintDecompiler;
 
 public static class BlueprintDecompilerUtils
 {
+    private static readonly ILogger Log = Serilog.Log.ForContext(typeof(BlueprintDecompilerUtils));
+    
     public static TypeMappings? Mappings { get; set; }
     public static UFunction Function { get; set; }
     private static readonly Stack<int> _executionFlowStack = new();

--- a/CUE4Parse/UE4/Objects/UObject/FPackageFileSummary.cs
+++ b/CUE4Parse/UE4/Objects/UObject/FPackageFileSummary.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Runtime.InteropServices;
-using System.Text;
-using CUE4Parse.Encryption.Aes;
 using CUE4Parse.UE4.Assets.Objects;
 using CUE4Parse.UE4.Assets.Readers;
 using CUE4Parse.UE4.Exceptions;
@@ -35,6 +33,8 @@ namespace CUE4Parse.UE4.Objects.UObject
     [JsonConverter(typeof(FPackageFileSummaryConverter))]
     public class FPackageFileSummary
     {
+        private static readonly ILogger Log = Serilog.Log.ForContext<FPackageFileSummary>();
+        
         public const uint PACKAGE_FILE_TAG = 0x9E2A83C1U;
         public const uint PACKAGE_FILE_TAG_SWAPPED = 0xC1832A9EU;
         public const uint PACKAGE_FILE_TAG_ACE7 = 0x37454341U; // ACE7

--- a/CUE4Parse/UE4/Objects/UObject/FSoftObjectPath.cs
+++ b/CUE4Parse/UE4/Objects/UObject/FSoftObjectPath.cs
@@ -18,6 +18,8 @@ namespace CUE4Parse.UE4.Objects.UObject;
 [JsonConverter(typeof(FSoftObjectPathConverter))]
 public readonly struct FSoftObjectPath : IUStruct
 {
+    private static readonly ILogger Log = Serilog.Log.ForContext<FSoftObjectPath>();
+    
     /** Asset path, patch to a top level object in a package. This is /package/path.assetname */
     public readonly FName AssetPathName;
     /** Optional FString for subobject within an asset. This is the sub path after the : */

--- a/CUE4Parse/UE4/Objects/UObject/UClass.cs
+++ b/CUE4Parse/UE4/Objects/UObject/UClass.cs
@@ -19,6 +19,8 @@ namespace CUE4Parse.UE4.Objects.UObject;
 [SkipObjectRegistration]
 public class UClass : UStruct
 {
+    private static readonly ILogger Log = Serilog.Log.ForContext<UClass>();
+    
     /** Used to check if the class was cooked or not */
     public bool bCooked;
 

--- a/CUE4Parse/UE4/Objects/UObject/UStruct.cs
+++ b/CUE4Parse/UE4/Objects/UObject/UStruct.cs
@@ -12,6 +12,8 @@ namespace CUE4Parse.UE4.Objects.UObject;
 [SkipObjectRegistration]
 public class UStruct : UField
 {
+    private static readonly ILogger Log = Serilog.Log.ForContext<UStruct>();
+    
     public FPackageIndex SuperStruct;
     public FPackageIndex[] Children;
     public FField[] ChildProperties;

--- a/CUE4Parse/UE4/Pak/Objects/FPakInfo.cs
+++ b/CUE4Parse/UE4/Pak/Objects/FPakInfo.cs
@@ -32,6 +32,8 @@ public enum EPakFileVersion
 
 public partial class FPakInfo
 {
+    private static readonly ILogger Log = Serilog.Log.ForContext<FPakInfo>();
+    
     public const uint PAK_FILE_MAGIC = 0x5A6F12E1;
     public const uint PAK_FILE_MAGIC_OutlastTrials = 0xA590ED1E;
     public const uint PAK_FILE_MAGIC_TorchlightInfinite = 0x6B2A56B8;

--- a/CUE4Parse/UE4/Pak/PakFileReader.cs
+++ b/CUE4Parse/UE4/Pak/PakFileReader.cs
@@ -26,6 +26,7 @@ using CUE4Parse.UE4.VirtualFileSystem;
 using CUE4Parse.Utils;
 using GenericReader;
 using OffiUtils;
+using Serilog;
 using static CUE4Parse.Compression.Compression;
 using static CUE4Parse.UE4.Pak.Objects.EPakFileVersion;
 
@@ -33,6 +34,8 @@ namespace CUE4Parse.UE4.Pak
 {
     public partial class PakFileReader : AbstractAesVfsReader
     {
+        private static readonly ILogger Log = Serilog.Log.ForContext<PakFileReader>();
+        
         public readonly FArchive Ar;
         public readonly FPakInfo Info;
 

--- a/CUE4Parse/UE4/Readers/FArchive.cs
+++ b/CUE4Parse/UE4/Readers/FArchive.cs
@@ -26,6 +26,8 @@ namespace CUE4Parse.UE4.Readers
 {
     public abstract class FArchive : RandomAccessStream, ICloneable
     {
+        private static readonly ILogger Log = Serilog.Log.ForContext<FArchive>();
+        
         public VersionContainer Versions;
         public EGame Game
         {

--- a/CUE4Parse/UE4/VirtualFileSystem/AbstractVfsReader.cs
+++ b/CUE4Parse/UE4/VirtualFileSystem/AbstractVfsReader.cs
@@ -14,7 +14,7 @@ namespace CUE4Parse.UE4.VirtualFileSystem
 {
     public abstract partial class AbstractVfsReader : IVfsReader
     {
-        protected static readonly ILogger Log = Serilog.Log.ForContext<AbstractVfsReader>();
+        private static readonly ILogger Log = Serilog.Log.ForContext<AbstractVfsReader>();
 
         public string Path { get; }
         public string Name { get; }

--- a/CUE4Parse/UE4/Wwise/Objects/HIRC/Hierarchy.cs
+++ b/CUE4Parse/UE4/Wwise/Objects/HIRC/Hierarchy.cs
@@ -10,6 +10,8 @@ namespace CUE4Parse.UE4.Wwise.Objects.HIRC;
 [JsonConverter(typeof(HierarchyConverter))]
 public readonly struct Hierarchy
 {
+    private static readonly ILogger Log = Serilog.Log.ForContext<Hierarchy>();
+    
     public readonly EAKBKHircType Type;
     public readonly uint Length;
     public readonly AbstractHierarchy Data;

--- a/CUE4Parse/UE4/Wwise/WwisePlugin.cs
+++ b/CUE4Parse/UE4/Wwise/WwisePlugin.cs
@@ -19,6 +19,8 @@ namespace CUE4Parse.UE4.Wwise;
 
 public class WwisePlugin
 {
+    private static readonly ILogger Log = Serilog.Log.ForContext<WwisePlugin>();
+    
     public static IAkPluginParam? TryParsePluginParams(FWwiseArchive Ar, AkPlugin plugin, bool always = false)
     {
         var pluginId = plugin.PluginId;

--- a/CUE4Parse/UE4/Wwise/WwiseProvider.cs
+++ b/CUE4Parse/UE4/Wwise/WwiseProvider.cs
@@ -29,6 +29,8 @@ public class WwiseExtractedSound
 
 public partial class WwiseProvider
 {
+    private static readonly ILogger Log = Serilog.Log.ForContext<WwiseProvider>();
+    
     private readonly AbstractVfsFileProvider _provider;
     private readonly string _gameDirectory;
     private string _baseWwiseAudioPath;

--- a/CUE4Parse/UE4/Wwise/WwiseReader.cs
+++ b/CUE4Parse/UE4/Wwise/WwiseReader.cs
@@ -24,6 +24,8 @@ public sealed record WwiseBulkDataSource(FAssetArchive AssetAr, FByteBulkData bu
 [JsonConverter(typeof(WwiseConverter))]
 public class WwiseReader
 {
+    private static readonly ILogger Log = Serilog.Log.ForContext<WwiseReader>();
+    
     public string Path;
     private readonly WwiseDataSource? _source;
 


### PR DESCRIPTION
- Added `ForContext` everywhere logs are used
- Without this, it is currently impossible to filter out log messages like so:
```csharp
new LoggerConfiguration()
  .MinimumLevel.Override("CUE4Parse", LogEventLevel.Error)
```

Closes #347 