### PR TITLE
Fix native library loading on Linux by resolving an absolute path

### DIFF
--- a/CUE4Parse/Compression/OodleHelper.cs
+++ b/CUE4Parse/Compression/OodleHelper.cs
@@ -150,9 +150,9 @@ public static class OodleHelper
 
     private static string ResolvePath(string? path)
     {
-        return !string.IsNullOrWhiteSpace(path)
+        return Path.GetFullPath(!string.IsNullOrWhiteSpace(path)
             ? path
-            : !OperatingSystem.IsLinux() && File.Exists(OODLE_NAME_OLD) ? OODLE_NAME_OLD : OodleFileName;
+            : !OperatingSystem.IsLinux() && File.Exists(OODLE_NAME_OLD) ? OODLE_NAME_OLD : OodleFileName);
     }
 
     [DoesNotReturn]

--- a/CUE4Parse/Compression/ZlibHelper.cs
+++ b/CUE4Parse/Compression/ZlibHelper.cs
@@ -39,7 +39,7 @@ public static class ZlibHelper
     {
         if (Instance is not null) return;
 
-        var dllPath = string.IsNullOrWhiteSpace(path) ? DllName : path;
+        var dllPath = Path.GetFullPath(string.IsNullOrWhiteSpace(path) ? DllName : path);
         if (!await DownloadDllAsync(dllPath, null, cancellationToken).ConfigureAwait(false))
         {
             Log.Warning("Zlib decompression failed: unable to download zlib-ng dll");

--- a/CUE4Parse/UE4/Lua/unluac/UnluacHelper.cs
+++ b/CUE4Parse/UE4/Lua/unluac/UnluacHelper.cs
@@ -47,7 +47,7 @@ public static class UnluacHelper
     {
         if (Instance is not null) return;
 
-        var dllPath = string.IsNullOrWhiteSpace(path) ? DllName : path;
+        var dllPath = Path.GetFullPath(string.IsNullOrWhiteSpace(path) ? DllName : path);
         if (!await DownloadDllAsync(dllPath, null, cancellationToken).ConfigureAwait(false))
         {
             Log.Warning("Unable to download unluac dll");


### PR DESCRIPTION
Fixes the exception for Linux
```
Unhandled exception. System.DllNotFoundException: Unable to load shared library 'libz-ng.so' or one of its dependencies. In order to help diagnose loading problems, consider using a tool like strace. If you're using glibc, consider setting the LD_DEBUG environment variable: 
libz-ng.so: cannot open shared object file: No such file or directory

   at System.Runtime.InteropServices.NativeLibrary.Load(String libraryPath)
```
when {library}Helper.Initialize() is being called without library path
