### PR TITLE
Kismet UE 4.8 and lower fixed

### DIFF
--- a/CUE4Parse/UE4/Kismet/KismetExpression.cs
+++ b/CUE4Parse/UE4/Kismet/KismetExpression.cs
@@ -363,6 +363,7 @@ public class EX_Context : KismetExpression
         ObjectExpression = Ar.ReadExpression();
         Offset = Ar.Read<uint>();
         RValuePointer = new FKismetPropertyPointer(Ar);
+        if (Ar.Game < EGame.GAME_UE4_9) Ar.Read<byte>(); // Property type
         ContextExpression = Ar.ReadExpression();
     }
 
@@ -703,7 +704,7 @@ public class EX_Let : KismetExpression
 
     public EX_Let(FKismetArchive Ar)
     {
-        Property = new FKismetPropertyPointer(Ar);
+        if (Ar.Game >= EGame.GAME_UE4_9) Property = new FKismetPropertyPointer(Ar);
         Variable = Ar.ReadExpression();
         Assignment = Ar.ReadExpression();
     }


### PR DESCRIPTION
EX_Let was a EX_LetBase before 4.9 and there was a byte in EX_Context before 4.9