### PR TITLE
Properly read UTF-8 names in Usmap

### DIFF
--- a/CUE4Parse/MappingsProvider/Usmap/UsmapArchiveExtensions.cs
+++ b/CUE4Parse/MappingsProvider/Usmap/UsmapArchiveExtensions.cs
@@ -19,11 +19,4 @@ public static class UsmapArchiveExtensions
     {
         return Ar.Read<int>();
     }
-
-    public static unsafe string ReadStringUnsafe(this FArchive Ar, int nameLength)
-    {
-        var nameBytes = stackalloc byte[nameLength];
-        Ar.Serialize(nameBytes, nameLength);
-        return new string((sbyte*) nameBytes, 0, nameLength);
-    }
 }

--- a/CUE4Parse/MappingsProvider/Usmap/UsmapParser.cs
+++ b/CUE4Parse/MappingsProvider/Usmap/UsmapParser.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using CUE4Parse.UE4.Exceptions;
 using CUE4Parse.UE4.Objects.Core.Serialization;
 using CUE4Parse.UE4.Readers;
@@ -82,7 +83,7 @@ public class UsmapParser
         for (var i = 0; i < nameSize; i++)
         {
             var nameLength = Ar.Version >= EUsmapVersion.LongFName ? Ar.Read<ushort>() : Ar.Read<byte>();
-            nameLut.Add(Ar.ReadStringUnsafe(nameLength));
+            nameLut.Add(Encoding.UTF8.GetString(Ar.ReadBytes(nameLength)));
         }
 
         var enumCount = Ar.Read<uint>();


### PR DESCRIPTION
This PR adds support for UTF-16 names in the usmap. UTF-16 names are serialized using wide chars (2 bytes) and a negative name length indicates if the string is UTF-16 or not (similar to FString in UE).