### PR TITLE
Optimize IoStore mounting and package indexing

### DIFF
--- a/CUE4Parse/FileProvider/Objects/GameFile.cs
+++ b/CUE4Parse/FileProvider/Objects/GameFile.cs
@@ -26,8 +26,9 @@ public abstract class GameFile
     public static readonly FrozenSet<string> UePackagePayloadExtensionsSet = UePackagePayloadExtensions.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
     public static readonly FrozenSet<string> UeKnownExtensionsSet = UeKnownExtensions.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
 
-    // so we don't end up with a lot of duplicate "uasset"s in memory
+    // Avoid retaining duplicate extension and directory strings for every file.
     private static readonly ConcurrentDictionary<string, string> _internedExtensions = new(StringComparer.OrdinalIgnoreCase);
+    private static readonly ConcurrentDictionary<string, string> _internedDirectories = new(StringComparer.Ordinal);
 
     private string _path;
     private string? _directory;
@@ -62,11 +63,23 @@ public abstract class GameFile
     }
     public long Size { get; protected init; }
 
-    public string Directory => _directory ??= Path.SubstringBeforeLast('/');
+    public string Directory => _directory ??= Intern(_internedDirectories, Path.SubstringBeforeLast('/'));
     public string PathWithoutExtension => _pathWithoutExtension ??= Path.SubstringBeforeLast('.');
     public string Name => _name ??= Path.SubstringAfterLast('/');
-    public string NameWithoutExtension => _nameWithoutExtension ??= Name.SubstringBeforeLast('.');
-    public string Extension => _extension ??= InternExtension(Name.SubstringAfterLast('.'));
+    public string NameWithoutExtension
+    {
+        get
+        {
+            if (_nameWithoutExtension is not null) return _nameWithoutExtension;
+
+            var nameStart = Path.LastIndexOf('/') + 1;
+            var extensionSeparator = Path.LastIndexOf('.');
+            return _nameWithoutExtension = extensionSeparator < nameStart
+                ? Name
+                : Path.Substring(nameStart, extensionSeparator - nameStart);
+        }
+    }
+    public string Extension => _extension ??= Intern(_internedExtensions, Name.SubstringAfterLast('.'));
 
     public bool IsUePackage => UePackageExtensionsSet.Contains(Extension);
     public bool IsUePackagePayload => UePackagePayloadExtensionsSet.Contains(Extension);
@@ -135,12 +148,6 @@ public abstract class GameFile
     public override string ToString() => Path;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static string InternExtension(string extension)
-    {
-        if (_internedExtensions.TryGetValue(extension, out var interned))
-            return interned;
-
-        _internedExtensions[extension] = extension;
-        return extension;
-    }
+    private static string Intern(ConcurrentDictionary<string, string> pool, string value) =>
+        pool.GetOrAdd(value, static candidate => candidate);
 }

--- a/CUE4Parse/FileProvider/Vfs/AbstractVfsFileProvider.cs
+++ b/CUE4Parse/FileProvider/Vfs/AbstractVfsFileProvider.cs
@@ -283,7 +283,11 @@ namespace CUE4Parse.FileProvider.Vfs
         {
             var countNewMounts = 0;
             var tasks = new LinkedList<Task>();
-            foreach (var reader in _unloadedVfs.Keys)
+            var readers = _unloadedVfs.Keys.ToArray();
+            Files.PreallocatePackageIndex(EstimatePackageIndexCapacity(readers.Where(reader =>
+                (!reader.IsEncrypted || CustomEncryption != null) && reader.HasDirectoryIndex)));
+
+            foreach (var reader in readers)
             {
                 VerifyGlobalData(reader);
 
@@ -327,9 +331,14 @@ namespace CUE4Parse.FileProvider.Vfs
         {
             var countNewMounts = 0;
             var tasks = new LinkedList<Task<IAesVfsReader?>>();
-            foreach (var (guid, key) in keys)
+            var submittedKeys = keys as IReadOnlyCollection<KeyValuePair<FGuid, FAesKey>> ?? keys.ToArray();
+            var submittedKeyGuids = submittedKeys.Select(x => x.Key).ToHashSet();
+            var readers = _unloadedVfs.Keys.Where(reader => submittedKeyGuids.Contains(reader.EncryptionKeyGuid)).ToArray();
+            Files.PreallocatePackageIndex(EstimatePackageIndexCapacity(readers.Where(reader => reader.HasDirectoryIndex)));
+
+            foreach (var (guid, key) in submittedKeys)
             {
-                foreach (var reader in _unloadedVfs.Keys.Where(it => it.EncryptionKeyGuid == guid))
+                foreach (var reader in readers.Where(it => it.EncryptionKeyGuid == guid))
                 {
                     if (reader.Game == GAME_FragPunk && reader.Name.Contains("global")) reader.AesKey = key;
                     VerifyGlobalData(reader);
@@ -370,6 +379,18 @@ namespace CUE4Parse.FileProvider.Vfs
             }
 
             return countNewMounts;
+        }
+
+        private static int EstimatePackageIndexCapacity(IEnumerable<IAesVfsReader> readers)
+        {
+            long capacity = 0;
+            foreach (var reader in readers)
+            {
+                if (reader is IoStoreReader ioStoreReader)
+                    capacity += ioStoreReader.GetPackageDataChunkCount();
+            }
+
+            return (int) Math.Min(capacity, int.MaxValue);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/CUE4Parse/FileProvider/Vfs/FileProviderDictionary.cs
+++ b/CUE4Parse/FileProvider/Vfs/FileProviderDictionary.cs
@@ -12,8 +12,9 @@ namespace CUE4Parse.FileProvider.Vfs
     {
         private readonly ConcurrentBag<KeyValuePair<long, IReadOnlyDictionary<string, GameFile>>> _indicesBag = new ();
 
-        private readonly ConcurrentDictionary<FPackageId, GameFile> _byId = new ();
-        public IReadOnlyDictionary<FPackageId, GameFile> ById => _byId;
+        private ConcurrentDictionary<FPackageId, GameFile>? _byId;
+        private int _count;
+        public IReadOnlyDictionary<FPackageId, GameFile> ById => GetPackageIndex();
 
         private readonly KeyEnumerable _keys;
         public IEnumerable<string> Keys => _keys;
@@ -25,6 +26,26 @@ namespace CUE4Parse.FileProvider.Vfs
         {
             _keys = new KeyEnumerable(this);
             _values = new ValueEnumerable(this);
+        }
+
+        internal void PreallocatePackageIndex(int capacity)
+        {
+            if (capacity <= 0 || Volatile.Read(ref _byId) is not null)
+                return;
+
+            var packageIndex = new ConcurrentDictionary<FPackageId, GameFile>(
+                Environment.ProcessorCount, capacity);
+            Interlocked.CompareExchange(ref _byId, packageIndex, null);
+        }
+
+        private ConcurrentDictionary<FPackageId, GameFile> GetPackageIndex()
+        {
+            var packageIndex = Volatile.Read(ref _byId);
+            if (packageIndex is not null)
+                return packageIndex;
+
+            var newPackageIndex = new ConcurrentDictionary<FPackageId, GameFile>();
+            return Interlocked.CompareExchange(ref _byId, newPackageIndex, null) ?? newPackageIndex;
         }
 
         public void FindPayloads(GameFile file, out GameFile? uexp, out IReadOnlyList<GameFile> ubulks, out IReadOnlyList<GameFile> uptnls, bool cookedIndexLookup = false)
@@ -75,25 +96,39 @@ namespace CUE4Parse.FileProvider.Vfs
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void AddFiles(IReadOnlyDictionary<string, GameFile> newFiles, long readOrder = 0)
+        public void AddFiles(IReadOnlyDictionary<string, GameFile> newFiles, long readOrder = 0,
+            IReadOnlyDictionary<FPackageId, GameFile>? packageFiles = null)
         {
-            foreach (var file in newFiles.Values)
+            if (packageFiles is null)
             {
-                // packages, their optional variant and their respective payloads share the same id
-                // only load the normal package in this dict for later use by IoPackage.ImportedPackages
-                if (file is FIoStoreEntry { IsUePackage: true } ioEntry && !file.NameWithoutExtension.EndsWith(".o"))
+                ConcurrentDictionary<FPackageId, GameFile>? packageIndex = null;
+                foreach (var file in newFiles.Values)
                 {
-                    _byId[ioEntry.ChunkId.AsPackageId()] = file;
+                    // packages, their optional variant and their respective payloads share the same id
+                    // only load the normal package in this dict for later use by IoPackage.ImportedPackages
+                    if (file is FIoStoreEntry { IsPackageData: true, IsOptionalPackage: false } ioEntry)
+                    {
+                        (packageIndex ??= GetPackageIndex())[ioEntry.ChunkId.AsPackageId()] = file;
+                    }
                 }
             }
+            else
+            {
+                var packageIndex = GetPackageIndex();
+                foreach (var (packageId, file) in packageFiles)
+                    packageIndex[packageId] = file;
+            }
+
             _indicesBag.Add(new KeyValuePair<long, IReadOnlyDictionary<string, GameFile>>(readOrder, newFiles));
+            Interlocked.Add(ref _count, newFiles.Count);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Clear()
         {
             _indicesBag.Clear();
-            _byId.Clear();
+            Volatile.Read(ref _byId)?.Clear();
+            Interlocked.Exchange(ref _count, 0);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -152,7 +187,7 @@ namespace CUE4Parse.FileProvider.Vfs
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
-        public int Count => _indicesBag.Sum(it => it.Value.Count);
+        public int Count => Volatile.Read(ref _count);
 
         private class KeyEnumerable : IEnumerable<string>
         {

--- a/CUE4Parse/GameTypes/LordOfMysteries/Vfs/LoMIoStoreReader.cs
+++ b/CUE4Parse/GameTypes/LordOfMysteries/Vfs/LoMIoStoreReader.cs
@@ -40,12 +40,13 @@ public sealed class LoMIoStoreReader(LoMIoStoreManifest manifest, LoMDirectoryIn
                 entry = new FIoStoreEntry(this, i);
             }
 
-            if (entry.IsEncrypted) EncryptedFileCount++;
-            if (entry.IsUePackage) PackageIdIndex[entry.ChunkId.AsPackageId()] = entry;
+            if (entry.IsPackageData && !entry.IsOptionalPackage)
+                PackageIdIndex[entry.ChunkId.AsPackageId()] = entry;
             files[entry.Path] = entry;
         }
 
         Files = files;
+        EncryptedFileCount = IsEncrypted ? files.Count : 0;
         InitializeContainerHeader();
 
         if (Globals.LogVfsMounts)

--- a/CUE4Parse/GameTypes/LordOfMysteries/Vfs/LoMIoStoreReader.cs
+++ b/CUE4Parse/GameTypes/LordOfMysteries/Vfs/LoMIoStoreReader.cs
@@ -40,8 +40,8 @@ public sealed class LoMIoStoreReader(LoMIoStoreManifest manifest, LoMDirectoryIn
                 entry = new FIoStoreEntry(this, i);
             }
 
-            if (entry.IsPackageData && !entry.IsOptionalPackage)
-                PackageIdIndex[entry.ChunkId.AsPackageId()] = entry;
+            if (entry.IsPackageData && chunkId._chunkIndex == 0 && !entry.IsOptionalPackage)
+                PackageIdIndex[chunkId.AsPackageId()] = entry;
             files[entry.Path] = entry;
         }
 

--- a/CUE4Parse/UE4/IO/IoStoreReader.cs
+++ b/CUE4Parse/UE4/IO/IoStoreReader.cs
@@ -20,13 +20,34 @@ namespace CUE4Parse.UE4.IO;
 
 public partial class IoStoreReader : AbstractAesVfsReader
 {
+    private readonly record struct DirectoryTraversal(uint Directory, int ParentPathLength);
+
     public readonly IReadOnlyList<FArchive> ContainerStreams;
 
     public readonly FIoStoreTocResource TocResource;
     public readonly Dictionary<FIoChunkId, FIoOffsetAndLength>? TocImperfectHashMapFallback;
     private Lazy<FIoContainerHeader?> _containerHeader;
+    private int _packageDataChunkCount = -1;
     public FIoContainerHeader? ContainerHeader => _containerHeader.Value;
     public Dictionary<FPackageId, GameFile> PackageIdIndex { get; private set; } = [];
+
+    internal int GetPackageDataChunkCount()
+    {
+        if (_packageDataChunkCount >= 0)
+            return _packageDataChunkCount;
+
+        var packageDataChunkType = Game >= GAME_UE5_0
+            ? (byte) EIoChunkType5.ExportBundleData
+            : (byte) EIoChunkType.ExportBundleData;
+        var count = 0;
+        foreach (ref readonly var chunkId in TocResource.ChunkIds.AsSpan())
+        {
+            if (chunkId.ChunkType == packageDataChunkType && chunkId._chunkIndex == 0)
+                count++;
+        }
+
+        return _packageDataChunkCount = count;
+    }
 
     public override string MountPoint { get; protected set; }
     public sealed override long Length { get; set; }
@@ -448,49 +469,74 @@ public partial class IoStoreReader : AbstractAesVfsReader
         var directoryEntries = directoryIndex.ReadArray<FIoDirectoryIndexEntry>();
         var fileEntries = directoryIndex.ReadArray<FIoFileIndexEntry>();
         var stringTable = directoryIndex.ReadFStringMemoryArray();
+        EncryptedFileCount = IsEncrypted ? fileEntries.Length : 0;
 
         var files = new Dictionary<string, GameFile>(fileEntries.Length, pathComparer);
         var dirNamePool = ArrayPool<char>.Shared.Rent(512);
-        var currentLength = Write(dirNamePool, 0, MountPoint);
-        ReadIndex(dirNamePool, currentLength, 0U);
-
-        void ReadIndex(char[] directoryName, int directoryLength, uint dir)
+        try
         {
-            const uint invalidHandle = uint.MaxValue;
-            while (dir != invalidHandle)
+            var mountPointLength = Write(dirNamePool, 0, MountPoint);
+            ReadIndex(dirNamePool, mountPointLength, directoryEntries, fileEntries, stringTable, files);
+            Files = files;
+        }
+        finally
+        {
+            ArrayPool<char>.Shared.Return(dirNamePool);
+        }
+    }
+
+    private void ReadIndex(char[] pathBuffer, int mountPointLength,
+        FIoDirectoryIndexEntry[] directoryEntries, FIoFileIndexEntry[] fileEntries,
+        FStringMemory[] stringTable, Dictionary<string, GameFile> files)
+    {
+        const uint invalidHandle = uint.MaxValue;
+        var packageDataChunkType = Game >= GAME_UE5_0
+            ? (byte) EIoChunkType5.ExportBundleData
+            : (byte) EIoChunkType.ExportBundleData;
+        PackageIdIndex = new Dictionary<FPackageId, GameFile>(GetPackageDataChunkCount());
+        var pendingDirectories = new Stack<DirectoryTraversal>(64);
+        pendingDirectories.Push(new DirectoryTraversal(0U, mountPointLength));
+
+        while (pendingDirectories.TryPop(out var traversal))
+        {
+            var dirEntry = directoryEntries[traversal.Directory];
+            var directoryLength = traversal.ParentPathLength;
+            if (dirEntry.Name != invalidHandle)
             {
-                var dirEntry = directoryEntries[dir];
-                var dirName = dirEntry.Name != invalidHandle ? stringTable[dirEntry.Name] : default;
-                var directoryLengthSnapshot = directoryLength;
+                var dirName = stringTable[dirEntry.Name];
                 if (!dirName.IsEmpty())
-                    directoryLength = Write(directoryName, directoryLength, dirName, false);
+                    directoryLength = Write(pathBuffer, directoryLength, dirName, false);
+            }
 
-                var file = dirEntry.FirstFileEntry;
-                while (file!= invalidHandle)
+            if (dirEntry.NextSiblingEntry != invalidHandle)
+                pendingDirectories.Push(new DirectoryTraversal(dirEntry.NextSiblingEntry, traversal.ParentPathLength));
+            if (dirEntry.FirstChildEntry != invalidHandle)
+                pendingDirectories.Push(new DirectoryTraversal(dirEntry.FirstChildEntry, directoryLength));
+
+            var file = dirEntry.FirstFileEntry;
+            while (file != invalidHandle)
+            {
+                var fileEntry = fileEntries[file];
+                var name = stringTable[fileEntry.Name];
+                var fullPathLength = Write(pathBuffer, directoryLength, name, true);
+                var fullPathSpan = pathBuffer.AsSpan(..fullPathLength);
+                if (Game == GAME_NeedForSpeedMobile) fullPathSpan = fullPathSpan.SubstringAfter("../../../");
+                var path = new string(fullPathSpan);
+
+                var entry = new FIoStoreEntry(this, path, fileEntry.UserData);
+                ref readonly var chunkId = ref TocResource.ChunkIds[fileEntry.UserData];
+                // Normal package data uses chunk index zero. Some optional segments use a non-zero index,
+                // while older containers identify them only through the ".o" package-path modifier.
+                if (chunkId.ChunkType == packageDataChunkType &&
+                    chunkId._chunkIndex == 0 && !FIoStoreEntry.IsOptionalPackagePath(path))
                 {
-                    var fileEntry = fileEntries[file];
-                    var name = stringTable[fileEntry.Name];
-                    var fullPathLength = Write(directoryName, directoryLength, name, true);
-                    var fullPathSpan = directoryName.AsSpan(..fullPathLength);
-                    if (Game == GAME_NeedForSpeedMobile) fullPathSpan = fullPathSpan.SubstringAfter("../../../");
-                    var path = new string(fullPathSpan);
-
-                    var entry = new FIoStoreEntry(this, path, fileEntry.UserData);
-                    if (entry.IsEncrypted) EncryptedFileCount++;
-                    if (entry.IsUePackage) PackageIdIndex[entry.ChunkId.AsPackageId()] = entry;
-                    files[path] = entry;
-
-                    file = fileEntry.NextFileEntry;
+                    PackageIdIndex[chunkId.AsPackageId()] = entry;
                 }
+                files[path] = entry;
 
-                ReadIndex(directoryName, directoryLength, dirEntry.FirstChildEntry);
-                dir = dirEntry.NextSiblingEntry;
-                directoryLength = directoryLengthSnapshot;
+                file = fileEntry.NextFileEntry;
             }
         }
-
-        Files = files;
-        ArrayPool<char>.Shared.Return(dirNamePool);
     }
 
     protected void InitializeContainerHeader() => _containerHeader = new Lazy<FIoContainerHeader?>(ReadContainerHeader);

--- a/CUE4Parse/UE4/IO/Objects/FIoStoreEntry.cs
+++ b/CUE4Parse/UE4/IO/Objects/FIoStoreEntry.cs
@@ -21,6 +21,26 @@ namespace CUE4Parse.UE4.IO.Objects
 
         private readonly uint _tocEntryIndex;
         public FIoChunkId ChunkId => IoStoreReader.TocResource.ChunkIds[_tocEntryIndex];
+        public bool IsPackageData
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => ChunkId.ChunkType == (IoStoreReader.Game >= GAME_UE5_0
+                ? (byte) EIoChunkType5.ExportBundleData
+                : (byte) EIoChunkType.ExportBundleData);
+        }
+        public bool IsOptionalPackage
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => IsOptionalPackagePath(Path);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static bool IsOptionalPackagePath(string path)
+        {
+            var extensionSeparator = path.LastIndexOf('.');
+            return extensionSeparator > 1 &&
+                   path.AsSpan(..extensionSeparator).EndsWith(".o", StringComparison.Ordinal);
+        }
 
         public FIoStoreEntry(IoStoreReader reader, string path, uint tocEntryIndex) : base(reader, path)
         {

--- a/CUE4Parse/UE4/IO/Objects/FIoStoreTocResource.cs
+++ b/CUE4Parse/UE4/IO/Objects/FIoStoreTocResource.cs
@@ -109,11 +109,19 @@ namespace CUE4Parse.UE4.IO.Objects
 
             // Compression blocks
             var isFragPunk = archive.Game == GAME_FragPunk;
-            CompressionBlocks = new FIoStoreTocCompressedBlockEntry[Header.TocCompressedBlockEntryCount];
-            for (int i = 0; i < Header.TocCompressedBlockEntryCount; i++)
+            if (!isFragPunk)
             {
-                CompressionBlocks[i] = new FIoStoreTocCompressedBlockEntry(archive);
-                if (isFragPunk) archive.Position += 4;
+                CompressionBlocks = archive.ReadArray<FIoStoreTocCompressedBlockEntry>(
+                    (int) Header.TocCompressedBlockEntryCount);
+            }
+            else
+            {
+                CompressionBlocks = new FIoStoreTocCompressedBlockEntry[Header.TocCompressedBlockEntryCount];
+                for (var i = 0; i < Header.TocCompressedBlockEntryCount; i++)
+                {
+                    CompressionBlocks[i] = new FIoStoreTocCompressedBlockEntry(archive);
+                    archive.Position += 4;
+                }
             }
 
             // Compression methods

--- a/CUE4Parse/UE4/VirtualFileSystem/AesVfsReaderForProvider.cs
+++ b/CUE4Parse/UE4/VirtualFileSystem/AesVfsReaderForProvider.cs
@@ -1,5 +1,6 @@
 ﻿using CUE4Parse.Encryption.Aes;
 using CUE4Parse.FileProvider.Vfs;
+using CUE4Parse.UE4.IO;
 
 namespace CUE4Parse.UE4.VirtualFileSystem
 {
@@ -9,7 +10,7 @@ namespace CUE4Parse.UE4.VirtualFileSystem
         {
             Mount(pathComparer);
 
-            files.AddFiles(Files, ReadOrder);
+            files.AddFiles(Files, ReadOrder, this is IoStoreReader ioStoreReader ? ioStoreReader.PackageIdIndex : null);
             vfsMounted?.Invoke(this, files.Count);
         }
     }


### PR DESCRIPTION
## Summary

- traverse IoStore directory indexes iteratively and bulk-read standard TOC compression blocks
- build and pre-size per-container package indexes while reading directory entries
- pre-size the provider-wide package index and reuse the reader indexes instead of rescanning every mounted file
- avoid repeated package-extension and encryption checks, keep provider file counts in O(1), and intern repeated directory/extension strings
- preserve optional-package filtering for both non-zero optional chunk indexes and older `.o` package paths

## Performance

In the paired CUE4Parse/FModel Fortnite startup profile, total CPU dropped from 25,273 to 19,519 units. The directly affected areas changed as follows:

- IoStore mount: 8,687 -> 6,100
- `FileProviderDictionary.AddFiles`: 2,681 -> 763
- provider-wide concurrent package insertion: 1,112 -> 693 in the final comparison

## Validation

- CUE4Parse test project builds with 0 errors
- 6 relevant tests pass
- Fortnite `pakchunk32-WindowsClient.utoc` package-index output matches the expected 247,486 normal packages exactly

The existing `DuplicateClassesTest` failure for `GuidCache` and `TextBuffer` is unrelated to these changes.