### PR TITLE
Add support for MulticastInlineDelegateProperty in BP decompiler

### DIFF
--- a/CUE4Parse/UE4/Objects/UObject/BlueprintDecompiler/BlueprintDecompilerUtils.cs
+++ b/CUE4Parse/UE4/Objects/UObject/BlueprintDecompiler/BlueprintDecompilerUtils.cs
@@ -422,6 +422,53 @@ public static class BlueprintDecompilerUtils
                 type = $"{enumProperty.Enum.Name}";
                 break;
             }
+            case FMulticastInlineDelegateProperty multicastInlineDelegate:
+            {
+                var signature = multicastInlineDelegate.SignatureFunction;
+                var functionSignature = signature.Load<UFunction>();
+
+                string returnType = "void";
+                var parametersList = new List<string>();
+
+                foreach (var childProperty in functionSignature?.ChildProperties ?? [])
+                {
+                    if (childProperty is not FProperty property2 || !property2.PropertyFlags.HasFlag(EPropertyFlags.Parm))
+                        continue;
+
+                    var (_, variableType) = GetPropertyType(property2);
+                    if (variableType is null)
+                        continue;
+
+                    if (property2.PropertyFlags.HasFlag(EPropertyFlags.ReturnParm))
+                    {
+                        returnType = variableType;
+                        continue;
+                    }
+
+                    parametersList.Add($"{variableType} {property2.Name}");
+                }
+
+                foreach (var child in functionSignature?.Children ?? [])
+                {
+                    if (child?.Load() is not UProperty property2 || !property2.PropertyFlags.HasFlag(EPropertyFlags.Parm))
+                        continue;
+
+                    var (_, variableType) = GetPropertyType(property2);
+                    if (variableType is null)
+                        continue;
+
+                    if (property2.PropertyFlags.HasFlag(EPropertyFlags.ReturnParm))
+                    {
+                        returnType = variableType;
+                        continue;
+                    }
+
+                    parametersList.Add($"{variableType} {property2.Name}");
+                }
+
+                type = $"TMulticastInlineDelegate<{returnType}({string.Join(", ", parametersList)})>";
+                break;
+            }
             case FVerseDynamicProperty:
             {
                 type = "DynamicVerse";
@@ -911,7 +958,49 @@ public static class BlueprintDecompilerUtils
             }
             case EPropertyType.MulticastInlineDelegateProperty:
             {
-                type = "FMulticastScriptDelegate";
+                var signature = propertyTag.GetGenericValue<FMulticastInlineDelegateProperty>().SignatureFunction;
+                var functionSignature = signature.Load<UFunction>();
+
+                string returnType = "void";
+                var parametersList = new List<string>();
+
+                foreach (var childProperty in functionSignature?.ChildProperties ?? [])
+                {
+                    if (childProperty is not FProperty property || !property.PropertyFlags.HasFlag(EPropertyFlags.Parm))
+                        continue;
+
+                    var (_, variableType) = GetPropertyType(property);
+                    if (variableType is null)
+                        continue;
+
+                    if (property.PropertyFlags.HasFlag(EPropertyFlags.ReturnParm))
+                    {
+                        returnType = variableType;
+                        continue;
+                    }
+
+                    parametersList.Add($"{variableType} {property.Name}");
+                }
+
+                foreach (var child in functionSignature?.Children ?? [])
+                {
+                    if (child?.Load() is not UProperty property || !property.PropertyFlags.HasFlag(EPropertyFlags.Parm))
+                        continue;
+
+                    var (_, variableType) = GetPropertyType(property);
+                    if (variableType is null)
+                        continue;
+
+                    if (property.PropertyFlags.HasFlag(EPropertyFlags.ReturnParm))
+                    {
+                        returnType = variableType;
+                        continue;
+                    }
+
+                    parametersList.Add($"{variableType} {property.Name}");
+                }
+
+                type = $"TMulticastInlineDelegate<{returnType}({string.Join(", ", parametersList)})>";
                 return true;
             }
             case EPropertyType.VerseFunctionProperty:

--- a/CUE4Parse/UE4/Objects/UObject/BlueprintDecompiler/BlueprintDecompilerUtils.cs
+++ b/CUE4Parse/UE4/Objects/UObject/BlueprintDecompiler/BlueprintDecompilerUtils.cs
@@ -958,6 +958,13 @@ public static class BlueprintDecompilerUtils
             }
             case EPropertyType.MulticastInlineDelegateProperty:
             {
+                if (propertyTag.Tag?.GenericValue is not FMulticastInlineDelegateProperty)
+                {
+                    Log.Warning("Property '{name}' is marked as '{propertyType}' but its GenericValue is '{genericValue}'",
+                        propertyTag.Name, propertyType.ToString(), propertyTag.Tag?.GenericValue?.GetType().Name);
+                    return false;
+                }
+
                 var signature = propertyTag.GetGenericValue<FMulticastInlineDelegateProperty>().SignatureFunction;
                 var functionSignature = signature.Load<UFunction>();
 

--- a/CUE4Parse/UE4/Objects/UObject/UClass.cs
+++ b/CUE4Parse/UE4/Objects/UObject/UClass.cs
@@ -138,7 +138,7 @@ public class UClass : UStruct
                 continue;
 
             var value = variableValue is null ? string.Empty : $" = {variableValue}";
-            variables.TryAdd($"{variableType} {property.Name.Text}{value};", property.GetAccessMode());
+            variables.TryAdd($"{variableType} {property.Name.Text.Replace(" ", "")}{value};", property.GetAccessMode());
         }
 
         foreach (var group in variables.GroupBy(pair => pair.Value))

--- a/CUE4Parse/UE4/Objects/UObject/UClass.cs
+++ b/CUE4Parse/UE4/Objects/UObject/UClass.cs
@@ -138,7 +138,7 @@ public class UClass : UStruct
                 continue;
 
             var value = variableValue is null ? string.Empty : $" = {variableValue}";
-            variables.TryAdd($"{variableType} {property.Name.Text.Replace(" ", "")}{value};", property.GetAccessMode());
+            variables.TryAdd($"{variableType} {property.Name.Text}{value};", property.GetAccessMode());
         }
 
         foreach (var group in variables.GroupBy(pair => pair.Value))


### PR DESCRIPTION
Add support for MulticastInlineDelegateProperty in the Blueprint decompiler.

Example:
<img width="780" height="127" alt="image" src="https://github.com/user-attachments/assets/f448bda9-e08e-48e4-a7d4-6fe07a2898c5" />
