### PR TITLE
Fix intermittent encrypted VFS mounting by submitting AES keys sequentially

### DIFF
--- a/CUE4Parse/FileProvider/Vfs/AbstractVfsFileProvider.cs
+++ b/CUE4Parse/FileProvider/Vfs/AbstractVfsFileProvider.cs
@@ -322,15 +322,10 @@ namespace CUE4Parse.FileProvider.Vfs
 
             foreach (var (guid, key) in keys)
             {
-                // Copiamos os leitores para um array e os ordenamos para garantir
-                // uma execução previsível e evitar alterações na coleção durante o loop.
                 var readers = _unloadedVfs.Keys
                     .Where(reader => reader.EncryptionKeyGuid == guid)
                     .OrderBy(reader => reader.Name, StringComparer.OrdinalIgnoreCase)
                     .ToArray();
-
-                System.Console.WriteLine(
-                    $"[AES DEBUG] SubmitKey iniciado. GUID={guid}, leitores={readers.Length}");
 
                 foreach (var reader in readers)
                 {
@@ -343,22 +338,13 @@ namespace CUE4Parse.FileProvider.Vfs
                     VerifyGlobalData(reader);
 
                     if (!reader.HasDirectoryIndex)
-                    {
-                        System.Console.WriteLine(
-                            $"[AES DEBUG] Ignorado sem DirectoryIndex: " +
-                            $"[{reader.GetType().Name}] {reader.Name}");
-
                         continue;
-                    }
 
                     try
                     {
-                        System.Console.WriteLine(
-                            $"[AES DEBUG] Montando: " +
-                            $"[{reader.GetType().Name}] {reader.Name}");
-
-                        // A diferença principal está aqui:
-                        // montamos um leitor por vez, sem Task.Run.
+                        // Mount readers sequentially. Some games, including
+                        // Neverness to Everness, may fail intermittently when
+                        // multiple encrypted readers are mounted concurrently.
                         reader.MountTo(Files, PathComparer, key, VfsMounted);
 
                         _unloadedVfs.TryRemove(reader, out _);
@@ -367,39 +353,27 @@ namespace CUE4Parse.FileProvider.Vfs
 
                         _requiredKeys.TryRemove(reader.EncryptionKeyGuid, out _);
                         _keys.TryAdd(reader.EncryptionKeyGuid, key);
-
-                        System.Console.WriteLine(
-                            $"[AES DEBUG] SUCESSO: " +
-                            $"[{reader.GetType().Name}] {reader.Name}");
                     }
                     catch (InvalidAesKeyException exception)
                     {
-                        // O código original ignorava completamente esta exceção.
-                        // Agora exibiremos tudo para descobrir a causa verdadeira.
-                        System.Console.WriteLine(
-                            $"[AES DEBUG] InvalidAesKeyException em " +
-                            $"[{reader.GetType().Name}] {reader.Name}");
-
-                        System.Console.WriteLine(exception.ToString());
+                        Log.Warning(
+                            exception,
+                            $"Failed to mount encrypted archive " +
+                            $"{reader.Path.SubstringAfterLast('/')}"
+                        );
                     }
                     catch (Exception exception)
                     {
-                        System.Console.WriteLine(
-                            $"[AES DEBUG] Exceção inesperada em " +
-                            $"[{reader.GetType().Name}] {reader.Name}");
-
-                        System.Console.WriteLine(exception.ToString());
+                        Log.Warning(
+                            exception,
+                            $"Uncaught exception while loading pak file " +
+                            $"{reader.Path.SubstringAfterLast('/')}"
+                        );
                     }
                 }
             }
 
-            // Mantemos o método assíncrono compatível com a interface existente,
-            // embora esta versão experimental execute as montagens sequencialmente.
             await Task.CompletedTask.ConfigureAwait(false);
-
-            System.Console.WriteLine(
-                $"[AES DEBUG] SubmitKey finalizado. Novas montagens={countNewMounts}");
-
             return countNewMounts;
         }
 

--- a/CUE4Parse/FileProvider/Vfs/AbstractVfsFileProvider.cs
+++ b/CUE4Parse/FileProvider/Vfs/AbstractVfsFileProvider.cs
@@ -319,48 +319,86 @@ namespace CUE4Parse.FileProvider.Vfs
         public async Task<int> SubmitKeysAsync(IEnumerable<KeyValuePair<FGuid, FAesKey>> keys)
         {
             var countNewMounts = 0;
-            var tasks = new LinkedList<Task<IAesVfsReader?>>();
+
             foreach (var (guid, key) in keys)
             {
-                foreach (var reader in _unloadedVfs.Keys.Where(it => it.EncryptionKeyGuid == guid))
+                // Copiamos os leitores para um array e os ordenamos para garantir
+                // uma execução previsível e evitar alterações na coleção durante o loop.
+                var readers = _unloadedVfs.Keys
+                    .Where(reader => reader.EncryptionKeyGuid == guid)
+                    .OrderBy(reader => reader.Name, StringComparer.OrdinalIgnoreCase)
+                    .ToArray();
+
+                System.Console.WriteLine(
+                    $"[AES DEBUG] SubmitKey iniciado. GUID={guid}, leitores={readers.Length}");
+
+                foreach (var reader in readers)
                 {
-                    if (reader.Game == EGame.GAME_FragPunk && reader.Name.Contains("global")) reader.AesKey = key;
+                    if (reader.Game == EGame.GAME_FragPunk &&
+                        reader.Name.Contains("global", StringComparison.OrdinalIgnoreCase))
+                    {
+                        reader.AesKey = key;
+                    }
+
                     VerifyGlobalData(reader);
 
                     if (!reader.HasDirectoryIndex)
-                        continue;
-
-                    tasks.AddLast(Task.Run(() =>
                     {
-                        try
-                        {
-                            reader.MountTo(Files, PathComparer, key, VfsMounted);
-                            _unloadedVfs.TryRemove(reader, out _);
-                            _mountedVfs[reader] = null;
-                            Interlocked.Increment(ref countNewMounts);
-                            return reader;
-                        }
-                        catch (InvalidAesKeyException)
-                        {
-                            // Ignore this
-                        }
-                        catch (Exception e)
-                        {
-                            Log.Warning(e, $"Uncaught exception while loading pak file {reader.Path.SubstringAfterLast('/')}");
-                        }
-                        return null;
-                    }));
+                        System.Console.WriteLine(
+                            $"[AES DEBUG] Ignorado sem DirectoryIndex: " +
+                            $"[{reader.GetType().Name}] {reader.Name}");
+
+                        continue;
+                    }
+
+                    try
+                    {
+                        System.Console.WriteLine(
+                            $"[AES DEBUG] Montando: " +
+                            $"[{reader.GetType().Name}] {reader.Name}");
+
+                        // A diferença principal está aqui:
+                        // montamos um leitor por vez, sem Task.Run.
+                        reader.MountTo(Files, PathComparer, key, VfsMounted);
+
+                        _unloadedVfs.TryRemove(reader, out _);
+                        _mountedVfs[reader] = null;
+                        countNewMounts++;
+
+                        _requiredKeys.TryRemove(reader.EncryptionKeyGuid, out _);
+                        _keys.TryAdd(reader.EncryptionKeyGuid, key);
+
+                        System.Console.WriteLine(
+                            $"[AES DEBUG] SUCESSO: " +
+                            $"[{reader.GetType().Name}] {reader.Name}");
+                    }
+                    catch (InvalidAesKeyException exception)
+                    {
+                        // O código original ignorava completamente esta exceção.
+                        // Agora exibiremos tudo para descobrir a causa verdadeira.
+                        System.Console.WriteLine(
+                            $"[AES DEBUG] InvalidAesKeyException em " +
+                            $"[{reader.GetType().Name}] {reader.Name}");
+
+                        System.Console.WriteLine(exception.ToString());
+                    }
+                    catch (Exception exception)
+                    {
+                        System.Console.WriteLine(
+                            $"[AES DEBUG] Exceção inesperada em " +
+                            $"[{reader.GetType().Name}] {reader.Name}");
+
+                        System.Console.WriteLine(exception.ToString());
+                    }
                 }
             }
 
-            var completed = await Task.WhenAll(tasks).ConfigureAwait(false);
-            foreach (var it in completed)
-            {
-                var key = it?.AesKey;
-                if (it == null || key == null) continue;
-                _requiredKeys.TryRemove(it.EncryptionKeyGuid, out _);
-                _keys.TryAdd(it.EncryptionKeyGuid, key);
-            }
+            // Mantemos o método assíncrono compatível com a interface existente,
+            // embora esta versão experimental execute as montagens sequencialmente.
+            await Task.CompletedTask.ConfigureAwait(false);
+
+            System.Console.WriteLine(
+                $"[AES DEBUG] SubmitKey finalizado. Novas montagens={countNewMounts}");
 
             return countNewMounts;
         }


### PR DESCRIPTION
## Summary

This change mounts encrypted VFS readers sequentially when submitting AES keys, instead of starting one `Task.Run` per matching reader.

It fixes an intermittent mounting failure reproduced with encrypted Neverness to Everness archives.

## Problem

Using the exact same:

- CUE4Parse build
- UEExtractor build
- AES key
- game files
- command-line arguments
- output directory structure

produced nondeterministic results while calling `SubmitKey`.

Successful runs mounted the encrypted readers and populated the provider normally.

Failed runs left the encrypted readers unloaded and resulted in an empty provider.

The failure was also reproduced using an isolated fixture containing only:

- `pakchunk0-Windows_0_P.pak`
- `pakchunk0-Windows_0_P.utoc`
- `pakchunk0-Windows_0_P.ucas`

This ruled out interaction with unrelated game archives.

## Results before this change

### Full game installation

10 independent process executions:

- 7 successful
- 3 failed

### Isolated archive fixture

10 independent process executions:

- 7 successful
- 3 failed

### UEExtractor with `--no-parallel`

10 independent process executions:

- 7 successful
- 3 failed

The `--no-parallel` option did not affect the internal parallelism inside `SubmitKeysAsync`.

Before `SubmitKey`, successful and failed runs had the same:

- reader count
- reader types
- reader names
- reader order
- encryption GUIDs
- required key count

The difference only appeared during encrypted reader mounting.

## Previous behavior

`SubmitKeysAsync` created one task for every matching reader and mounted them concurrently.

Simplified previous flow:

    tasks.AddLast(Task.Run(() =>
    {
        reader.MountTo(...);
    }));

After creating all tasks, the method waited for them together with `Task.WhenAll`.

`InvalidAesKeyException` was silently ignored.

This made the intermittent mounting failure look like an invalid AES key, even though the exact same key succeeded in other executions.

## Change

Matching readers are now:

1. copied from `_unloadedVfs` into a fixed array;
2. filtered by encryption GUID;
3. ordered deterministically by reader name;
4. mounted one at a time.

Simplified new flow:

    var readers = _unloadedVfs.Keys
        .Where(reader => reader.EncryptionKeyGuid == guid)
        .OrderBy(reader => reader.Name, StringComparer.OrdinalIgnoreCase)
        .ToArray();

    foreach (var reader in readers)
    {
        reader.MountTo(...);
    }

The array snapshot also avoids directly enumerating `_unloadedVfs` while successfully mounted readers are removed from it.

Mount failures are now logged instead of being silently discarded.

## Results after this change

### Diagnostic version

Isolated fixture:

- 50 successful executions out of 50
- 0 mounting failures

Full game installation:

- 10 successful executions out of 10
- 0 mounting failures

### Clean version

Isolated fixture:

- 10 successful executions out of 10
- 0 mounting failures

Full game installation:

- 3 successful executions out of 3
- 0 mounting failures

### Combined result

- 73 successful executions
- 0 failed executions

Every isolated run produced:

- 6,560 virtual files
- 89,261 localization entries
- identical output file sizes

Every full-installation run:

- mounted the expected encrypted readers;
- left the same two unrelated readers unloaded;
- populated approximately 534,662 virtual files.

## Technical conclusion

The results strongly indicate that concurrent encrypted reader mounting was the trigger for the intermittent failure.

This change does not claim to identify the exact lower-level shared state responsible for the race.

The sequential implementation prioritizes deterministic and reliable mounting over parallel mounting performance.