### PR TITLE
feat: Features from the Fortnite Porting Fork

### DIFF
--- a/CUE4Parse-Conversion/Textures/TextureDecoder.cs
+++ b/CUE4Parse-Conversion/Textures/TextureDecoder.cs
@@ -223,9 +223,9 @@ public static class TextureDecoder
         }
     }
 
-    public static unsafe CTexture[]? DecodeTextureArray(this UTexture2DArray texture, ETexturePlatform platform = ETexturePlatform.DesktopMobile)
+    public static unsafe CTexture[]? DecodeTextureArray(this UTexture2DArray texture, FTexture2DMipMap? mip = null, ETexturePlatform platform = ETexturePlatform.DesktopMobile)
     {
-        var mip = texture.GetFirstMip();
+        mip ??= texture.GetFirstMip();
 
         if (mip is null)
             return null;
@@ -243,7 +243,8 @@ public static class TextureDecoder
         DecodeTexture(texture, mip, sizeX, sizeY, sizeZ, platform, out var data, out var colorType);
 
         var bitmaps = new CTexture[sizeZ];
-        var offset = sizeX * sizeY * 4;
+        var bytesPerPixel = GetBytesPerPixel(colorType);
+        var offset = sizeX * sizeY * bytesPerPixel;
 
         fixed (byte* dataPtr = data)
         {
@@ -251,7 +252,7 @@ public static class TextureDecoder
             {
                 if (offset * (i + 1) > data.Length)
                     break;
-                bitmaps[i] = new CTexture(sizeX, sizeY, colorType, GetSliceData(dataPtr, sizeX, sizeY, 4, i).ToArray());
+                bitmaps[i] = new CTexture(sizeX, sizeY, colorType, GetSliceData(dataPtr, sizeX, sizeY, bytesPerPixel, i).ToArray());
             }
         }
         return bitmaps;
@@ -477,5 +478,12 @@ public static class TextureDecoder
             default:
                 throw new NotImplementedException($"Unknown pixel format: {formatInfo.UnrealFormat}");
         }
+    }
+    
+    private static int GetBytesPerPixel(EPixelFormat pixelFormat)
+    {
+        var formatKvp = PixelFormatUtils.PixelFormats.ElementAtOrDefault((int) pixelFormat)!;
+        var formatInfo = formatKvp.Value;
+        return formatInfo.BlockBytes / (formatInfo.BlockSizeX * formatInfo.BlockSizeY * formatInfo.BlockSizeZ);
     }
 }

--- a/CUE4Parse/UE4/AssetRegistry/Objects/FPartialAssetData.cs
+++ b/CUE4Parse/UE4/AssetRegistry/Objects/FPartialAssetData.cs
@@ -9,6 +9,8 @@ public class FPartialAssetData
     public readonly FName PackageName;
     public readonly FName AssetName;
     public readonly FName AssetClass;
+    
+    public string ObjectPath => $"{PackageName}.{AssetName}";
 
     public FPartialAssetData(FAssetRegistryArchive Ar)
     {

--- a/CUE4Parse/UE4/Assets/Exports/Component/Landscape/ULandscapeComponent.cs
+++ b/CUE4Parse/UE4/Assets/Exports/Component/Landscape/ULandscapeComponent.cs
@@ -1,4 +1,5 @@
 using CUE4Parse.UE4.Assets.Exports.BuildData;
+using CUE4Parse.UE4.Assets.Exports.Material;
 using CUE4Parse.UE4.Assets.Exports.Texture;
 using CUE4Parse.UE4.Assets.Objects;
 using CUE4Parse.UE4.Assets.Readers;
@@ -22,6 +23,8 @@ public class ULandscapeComponent : UPrimitiveComponent
     public FWeightmapLayerAllocationInfo[] WeightmapLayerAllocations;
     public FBox CachedLocalBox;
     public FGuid MapBuildDataId;
+    
+    public UMaterialInterface? OverrideMaterial;
 
     public Lazy<UTexture2D[]> WeightmapTextures;
 
@@ -48,6 +51,8 @@ public class ULandscapeComponent : UPrimitiveComponent
         MapBuildDataId = GetOrDefault<FGuid>(nameof(MapBuildDataId));
         WeightmapTextures = new Lazy<UTexture2D[]>(() => GetOrDefault<UTexture2D[]>("WeightmapTextures", []));
         NamedGrassTypes = GetOrDefault<Dictionary<FName, FPackageIndex>>(nameof(NamedGrassTypes), []);
+        
+        OverrideMaterial = GetOrDefault<UMaterialInterface>(nameof(OverrideMaterial));
 
         if (FRenderingObjectVersion.Get(Ar) < FRenderingObjectVersion.Type.MapBuildDataSeparatePackage)
         {

--- a/CUE4Parse/UE4/Assets/Exports/Component/USceneComponent.cs
+++ b/CUE4Parse/UE4/Assets/Exports/Component/USceneComponent.cs
@@ -25,11 +25,19 @@ public class USceneComponent : UActorComponent
     public FPackageIndex? AttachParent;
     public FBoxSphereBounds? Bounds;
     public bool bIsCooked;
+    
+    public FVector RelativeLocation;
+    public FRotator RelativeRotation;
+    public FVector RelativeScale3D;
 
     public override void Deserialize(FAssetArchive Ar, long validPos)
     {
         base.Deserialize(Ar, validPos);
         AttachParent = GetOrDefault<FPackageIndex?>(nameof(AttachParent));
+        
+        RelativeLocation = GetOrDefault(nameof(RelativeLocation), FVector.ZeroVector);
+        RelativeRotation = GetOrDefault(nameof(RelativeRotation), FRotator.ZeroRotator);
+        RelativeScale3D = GetOrDefault(nameof(RelativeScale3D), FVector.OneVector);
 
         if (Ar.Game == GAME_WorldofJadeDynasty) Ar.Position += 4;
         var bComputeBoundsOnceForGame = GetOrDefault<bool>("bComputeBoundsOnceForGame");

--- a/CUE4Parse/UE4/Objects/Core/Math/FLinearColor.cs
+++ b/CUE4Parse/UE4/Objects/Core/Math/FLinearColor.cs
@@ -9,12 +9,12 @@ namespace CUE4Parse.UE4.Objects.Core.Math
     /// A linear, 32-bit/component floating point RGBA color.
     /// </summary>
     [StructLayout(LayoutKind.Sequential)]
-    public readonly struct FLinearColor : IUStruct
+    public struct FLinearColor : IUStruct
     {
-        public readonly float R;
-        public readonly float G;
-        public readonly float B;
-        public readonly float A;
+        public float R;
+        public float G;
+        public float B;
+        public float A;
 
         public static readonly FLinearColor Gray = new(0.6f, 0.6f, 0.6f, 1f);
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,7 +21,7 @@
     <PackageVersion Include="SharpGLTF.Core" Version="1.0.6" />
     <PackageVersion Include="SharpGLTF.Toolkit" Version="1.0.6" />
     <PackageVersion Include="SixLabors.ImageSharp" Version="[3.1.12]" />
-    <PackageVersion Include="SkiaSharp" Version="[2.88.9]" />
+    <PackageVersion Include="SkiaSharp" Version="[3.119.4]" />
     <PackageVersion Include="SubstreamSharp" Version="1.0.3" />
     <PackageVersion Include="System.IO.Hashing" Version="10.0.8" />
     <PackageVersion Include="System.Numerics.Tensors" Version="10.0.10" />


### PR DESCRIPTION
- Makes `FLinearColor` non read-only for deferred field creation and modifications of existing color channels.
- Adds the relative transform properties to `USceneComponent`
- Adds the `OverrideMaterial` field to `ULandscapeComponent`
- Fixes texture array decoding with proper usage of `bytesPerPixel`
- Adds `ObjectPath` to `FPartialAssetData` to match `FAssetData`
- Bumps skia to 3.119.4 to reduce Avalonia issues and needing to explicitly include this latest version