### PR TITLE
Preserve volume texture depth in FTexturePlatformData

### DIFF
--- a/CUE4Parse-Conversion/Textures/TextureDecoder.cs
+++ b/CUE4Parse-Conversion/Textures/TextureDecoder.cs
@@ -242,6 +242,12 @@ public static class TextureDecoder
         {
             var slices = texture.PlatformData.GetNumSlices();
             if (texture.Owner?.Provider?.Versions.Game == EGame.GAME_Borderlands4) slices = slices != 1 ? slices >> 1 : 1;
+            
+            // A volume's depth shrinks with every mip and is written on the mip itself, while
+            // PackedData only describes mip 0 and doesn't always work with it. Mips below 4.20
+            // have no depth at all, so we fall back to the slice count when there's nothing usable
+            if (texture is UVolumeTexture && sizeZ > 1) slices = sizeZ;
+
             sizeY *= slices;
             if (sizeZ == slices) sizeZ = 1;
         }

--- a/CUE4Parse-Conversion/Textures/TextureDecoder.cs
+++ b/CUE4Parse-Conversion/Textures/TextureDecoder.cs
@@ -12,6 +12,7 @@ using CUE4Parse_Conversion.Textures.Crunch;
 using CUE4Parse.Compression;
 using CUE4Parse.UE4.Assets.Exports.Texture;
 using CUE4Parse.UE4.Exceptions;
+using CUE4Parse.UE4.Versions;
 using CUE4Parse.Utils;
 
 namespace CUE4Parse_Conversion.Textures;
@@ -28,20 +29,9 @@ public static class TextureDecoder
         if (texture.PlatformData is { FirstMipToSerialize: >= 0, VTData: { } vt } && vt.IsInitialized())
             return DecodeVT(texture, vt);
 
-        if (mip == null)
-            return null;
+        if (mip is null) return null; // TODO: we should let it throw the exception
 
-        var sizeX = mip.SizeX;
-        var sizeY = mip.SizeY;
-        var sizeZ = mip.SizeZ;
-
-        if (texture.Format == EPixelFormat.PF_BC7)
-        {
-            sizeX = sizeX.Align(4);
-            sizeY = sizeY.Align(4);
-        }
-
-        DecodeTexture(texture, mip, sizeX, sizeY, sizeZ, platform, out var data, out var colorType);
+        DecodeTexture(texture, mip, platform, out var data, out var colorType, out var sizeX, out var sizeY, out var sizeZ);
         return new CTexture(sizeX, sizeY, colorType, data);
     }
 
@@ -51,20 +41,9 @@ public static class TextureDecoder
             return DecodeVT(texture, vt, mipIndex);
 
         var mip = texture.GetMip(mipIndex);
-        if (mip == null)
-            return null;
+        if (mip is null) return null; // TODO: we should let it throw the exception
 
-        var sizeX = mip.SizeX;
-        var sizeY = mip.SizeY;
-        var sizeZ = mip.SizeZ;
-
-        if (texture.Format == EPixelFormat.PF_BC7)
-        {
-            sizeX = sizeX.Align(4);
-            sizeY = sizeY.Align(4);
-        }
-
-        DecodeTexture(texture, mip, sizeX, sizeY, sizeZ, platform, out var data, out var colorType);
+        DecodeTexture(texture, mip, platform, out var data, out var colorType, out var sizeX, out var sizeY, out var sizeZ);
         return new CTexture(sizeX, sizeY, colorType, data);
     }
 
@@ -226,21 +205,9 @@ public static class TextureDecoder
     public static unsafe CTexture[]? DecodeTextureArray(this UTexture2DArray texture, FTexture2DMipMap? mip = null, ETexturePlatform platform = ETexturePlatform.DesktopMobile)
     {
         mip ??= texture.GetFirstMip();
+        if (mip is null) return null; // TODO: we should let it throw the exception
 
-        if (mip is null)
-            return null;
-
-        var sizeX = mip.SizeX;
-        var sizeY = mip.SizeY;
-        var sizeZ = mip.SizeZ;
-
-        if (texture.Format == EPixelFormat.PF_BC7)
-        {
-            sizeX = sizeX.Align(4);
-            sizeY = sizeY.Align(4);
-        }
-
-        DecodeTexture(texture, mip, sizeX, sizeY, sizeZ, platform, out var data, out var colorType);
+        DecodeTexture(texture, mip, platform, out var data, out var colorType, out var sizeX, out var sizeY, out var sizeZ);
 
         var bitmaps = new CTexture[sizeZ];
         var bytesPerPixel = GetBytesPerPixel(colorType);
@@ -258,7 +225,7 @@ public static class TextureDecoder
         return bitmaps;
     }
 
-    private static void DecodeTexture(UTexture texture, FTexture2DMipMap? mip, int sizeX, int sizeY, int sizeZ, ETexturePlatform platform, out byte[] data, out EPixelFormat colorType)
+    private static void DecodeTexture(UTexture texture, FTexture2DMipMap? mip, ETexturePlatform platform, out byte[] data, out EPixelFormat colorType, out int sizeX, out int sizeY, out int sizeZ)
     {
         var format = texture.Format;
         if (mip?.BulkData?.Data is not { Length: > 0 })
@@ -267,6 +234,23 @@ public static class TextureDecoder
             throw new NotImplementedException($"The supplied pixel format {format} is not supported!");
 
         var bytes = mip.BulkData.Data;
+        sizeX = mip.SizeX;
+        sizeY = mip.SizeY;
+        sizeZ = mip.SizeZ;
+
+        if (texture is UVolumeTexture or UTextureCube)
+        {
+            var slices = texture.PlatformData.GetNumSlices();
+            if (texture.Owner?.Provider?.Versions.Game == EGame.GAME_Borderlands4) slices = slices != 1 ? slices >> 1 : 1;
+            sizeY *= slices;
+            if (sizeZ == slices) sizeZ = 1;
+        }
+
+        if (format == EPixelFormat.PF_BC7)
+        {
+            sizeX = sizeX.Align(4);
+            sizeY = sizeY.Align(4);
+        }
 
         // TODO: Only known game to use this is PUBG Mobile, not sure if this is right place to decompress, probably not and should be refactored
         if (texture.PlatformData.PixelFormat.EndsWith("_crunched", StringComparison.OrdinalIgnoreCase))

--- a/CUE4Parse-Conversion/Textures/TextureDecoder.cs
+++ b/CUE4Parse-Conversion/Textures/TextureDecoder.cs
@@ -241,12 +241,18 @@ public static class TextureDecoder
         if (texture is UVolumeTexture or UTextureCube)
         {
             var slices = texture.PlatformData.GetNumSlices();
-            if (texture.Owner?.Provider?.Versions.Game == EGame.GAME_Borderlands4) slices = slices != 1 ? slices >> 1 : 1;
+            if (texture.Owner?.Provider?.Versions.Game == EGame.GAME_Borderlands4)
+            {
+                slices = slices != 1 ? slices >> 1 : 1;
+            }
             
             // A volume's depth shrinks with every mip and is written on the mip itself, while
             // PackedData only describes mip 0 and doesn't always work with it. Mips below 4.20
             // have no depth at all, so we fall back to the slice count when there's nothing usable
-            if (texture is UVolumeTexture && sizeZ > 1) slices = sizeZ;
+            if (texture is UVolumeTexture && sizeZ > 1)
+            {
+                slices = sizeZ;
+            }
 
             sizeY *= slices;
             if (sizeZ == slices) sizeZ = 1;

--- a/CUE4Parse/UE4/Assets/Exports/Texture/FTexturePlatformData.cs
+++ b/CUE4Parse/UE4/Assets/Exports/Texture/FTexturePlatformData.cs
@@ -42,8 +42,7 @@ public class FTexturePlatformData
     private const uint BitMask_NumSlices = BitMask_HasOptData - 1u;
 
     public readonly int SizeX;
-    public int SizeY;
-    public int SizeZ = 1; // How many slices got folded into SizeY: 1 for a simple texture, 6 for a cubemap, the depth for a volume
+    public readonly int SizeY;
     public readonly uint PackedData; // NumSlices: 1 for simple texture, 6 for cubemap - 6 textures are joined into one
     public readonly string PixelFormat;
     public readonly FOptTexturePlatformData OptData;
@@ -138,18 +137,6 @@ public class FTexturePlatformData
         for (var i = 0; i < Mips.Length; i++)
         {
             Mips[i] = new FTexture2DMipMap(Ar, bSerializeMipData);
-
-            if (Owner is UVolumeTexture or UTextureCube)
-            {
-                var slices = GetNumSlices();
-                if (Ar.Game == GAME_Borderlands4) slices = slices != 1 ? slices >> 1 : 1;
-                
-                if (Owner is UVolumeTexture && Mips[i].SizeZ > 1) slices = Mips[i].SizeZ;
-                if (i == 0) SizeZ = slices;
-                
-                Mips[i].SizeY *= slices;
-                Mips[i].SizeZ = Mips[i].SizeZ == slices ? 1 : Mips[i].SizeZ;
-            }
         }
 
         if (Ar.Versions["VirtualTextures"])
@@ -168,9 +155,6 @@ public class FTexturePlatformData
         {
             SizeX = Mips[0].SizeX;
             SizeY = Mips[0].SizeY;
-
-            if (Owner is UVolumeTexture)
-                PackedData = (uint) ((Mips[0].SizeZ & BitMask_NumSlices) | (PackedData & ~BitMask_NumSlices));
         }
         else if (VTData != null)
         {

--- a/CUE4Parse/UE4/Assets/Exports/Texture/FTexturePlatformData.cs
+++ b/CUE4Parse/UE4/Assets/Exports/Texture/FTexturePlatformData.cs
@@ -15,6 +15,7 @@ public struct FSharedImage
 {
     public readonly int SizeX;
     public readonly int SizeY;
+    public int SizeZ = 1;
     public readonly int SizeZ;
     public readonly EPixelFormat Format;
     public readonly byte GammaSpace;
@@ -142,6 +143,10 @@ public class FTexturePlatformData
             {
                 var slices = GetNumSlices();
                 if (Ar.Game == GAME_Borderlands4) slices = slices != 1 ? slices >> 1 : 1;
+                
+                if (Owner is UVolumeTexture && Mips[i].SizeZ > 1) slices = Mips[i].SizeZ;
+                if (i == 0) SizeZ = slices;
+                
                 Mips[i].SizeY *= slices;
                 Mips[i].SizeZ = Mips[i].SizeZ == slices ? 1 : Mips[i].SizeZ;
             }

--- a/CUE4Parse/UE4/Assets/Exports/Texture/FTexturePlatformData.cs
+++ b/CUE4Parse/UE4/Assets/Exports/Texture/FTexturePlatformData.cs
@@ -16,7 +16,6 @@ public struct FSharedImage
     public readonly int SizeX;
     public readonly int SizeY;
     public int SizeZ = 1;
-    public readonly int SizeZ;
     public readonly EPixelFormat Format;
     public readonly byte GammaSpace;
     public readonly FTexture2DMipMap Mip;

--- a/CUE4Parse/UE4/Assets/Exports/Texture/FTexturePlatformData.cs
+++ b/CUE4Parse/UE4/Assets/Exports/Texture/FTexturePlatformData.cs
@@ -15,7 +15,7 @@ public struct FSharedImage
 {
     public readonly int SizeX;
     public readonly int SizeY;
-    public int SizeZ = 1;
+    public readonly int SizeZ;
     public readonly EPixelFormat Format;
     public readonly byte GammaSpace;
     public readonly FTexture2DMipMap Mip;
@@ -43,6 +43,7 @@ public class FTexturePlatformData
 
     public readonly int SizeX;
     public int SizeY;
+    public int SizeZ = 1; // How many slices got folded into SizeY: 1 for a simple texture, 6 for a cubemap, the depth for a volume
     public readonly uint PackedData; // NumSlices: 1 for simple texture, 6 for cubemap - 6 textures are joined into one
     public readonly string PixelFormat;
     public readonly FOptTexturePlatformData OptData;

--- a/CUE4Parse/UE4/Assets/Exports/Texture/UTexture.cs
+++ b/CUE4Parse/UE4/Assets/Exports/Texture/UTexture.cs
@@ -165,6 +165,9 @@ public class UTexture : UUnrealMaterial, IAssetUserData
         writer.WritePropertyName(nameof(PlatformData.SizeY));
         writer.WriteValue(PlatformData.SizeY);
 
+        writer.WritePropertyName(nameof(PlatformData.SizeZ));
+        writer.WriteValue(PlatformData.SizeZ);
+
         writer.WritePropertyName(nameof(PlatformData.PackedData));
         writer.WriteValue(PlatformData.PackedData);
 

--- a/CUE4Parse/UE4/Assets/Exports/Texture/UTexture.cs
+++ b/CUE4Parse/UE4/Assets/Exports/Texture/UTexture.cs
@@ -165,9 +165,6 @@ public class UTexture : UUnrealMaterial, IAssetUserData
         writer.WritePropertyName(nameof(PlatformData.SizeY));
         writer.WriteValue(PlatformData.SizeY);
 
-        writer.WritePropertyName(nameof(PlatformData.SizeZ));
-        writer.WriteValue(PlatformData.SizeZ);
-
         writer.WritePropertyName(nameof(PlatformData.PackedData));
         writer.WriteValue(PlatformData.PackedData);
 


### PR DESCRIPTION
Volume slices are folded into `SizeY`, and `PackedData` is then overwritten with the mip's `SizeZ` (1), so the depth is unrecoverable afterwards `SizeY` alone can't be split back into height x depth.

- Add `SizeZ`, the slice count folded into `SizeY`: 1 for a flat texture, 6 for a cubemap, the depth for a volume.
- Fold using the mip's own `SizeZ` for volumes instead of `PackedData`.

The second is a fix on its own. On some volumes `PackedData`'s slice count disagrees with the mip, which inflates `SizeY` at every level. `VT_CurlNoise_LOW` is 32^3 but came out as 32x4096 instead of 32x1024, and no mip's reported size matched its payload. Taking the count from the mip also fixes the lower mips of volumes generally, which previously used mip 0's depth for the whole chain (512x512x32 caustics: mip 1 read 256x8192, holds 256x4096).

Checked against a UE5.1 build: all 25 volume textures and 55 cubemaps now have `SizeX * SizeY * bytes-per-pixel` equal to their mip 0 payload exactly, and 4000 2D textures are unchanged.

### PS: Adds SizeZ to VolumeTexture's exports