### PR TITLE
feat: add `NaniteSeparate` option to `ENaniteMeshFormat`

### DIFF
--- a/CUE4Parse-Conversion/Dto/MeshDto.cs
+++ b/CUE4Parse-Conversion/Dto/MeshDto.cs
@@ -157,6 +157,28 @@ public abstract class MeshDto<TVertex> : ObjectDto where TVertex : struct, IMesh
         }
     }
 
+    internal T WithLods<T>(Func<MeshLodDto<TVertex>, bool> predicate, Func<T> action)
+    {
+        var original = LODs.ToList();
+        foreach (var lod in original.Where(lod => !predicate(lod)))
+        {
+            LODs.Remove(lod);
+        }
+
+        try
+        {
+            return action();
+        }
+        finally
+        {
+            LODs.Clear();
+            foreach (var lod in original)
+            {
+                LODs.Add(lod);
+            }
+        }
+    }
+
     public override void Dispose()
     {
         LODs.Clear();

--- a/CUE4Parse-Conversion/Formats/Meshes/UEFormatMeshFormat.cs
+++ b/CUE4Parse-Conversion/Formats/Meshes/UEFormatMeshFormat.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using CUE4Parse_Conversion.Dto;
 using CUE4Parse_Conversion.Options;
 using CUE4Parse_Conversion.Writers.UEFormat;
@@ -12,16 +13,35 @@ public sealed class UEFormatMeshFormat : IMeshExportFormat
 
     public IReadOnlyList<ExportFile> BuildSkeletalMesh(string objectName, ExportOptions options, SkeletalMeshDto dto, IReadOnlyDictionary<string, string>? materialPaths = null)
     {
-        using var ar = new FArchiveWriter();
-        new UEModel(objectName, dto, options).Save(ar);
-        return [new ExportFile("uemodel", ar.GetBuffer())];
+        // if we are exporting nanite as a separate lod AND have a split of nanite lod vs. non-nanite lods
+        if (options.NaniteMeshFormat == ENaniteMeshFormat.NaniteSeparate 
+            && dto.LODs.Any(l => l.IsNanite) 
+            && dto.LODs.Any(l => !l.IsNanite))
+        {
+            return
+            [
+                dto.WithLods(lod => !lod.IsNanite, () => Save(objectName, dto, options)),
+                dto.WithLods(lod => lod.IsNanite, () => Save(objectName, dto, options, "_Nanite")),
+            ];
+        }
+
+        return [Save(objectName, dto, options)];
     }
 
     public IReadOnlyList<ExportFile> BuildStaticMesh(string objectName, ExportOptions options, StaticMeshDto dto, IReadOnlyDictionary<string, string>? materialPaths = null)
     {
-        using var ar = new FArchiveWriter();
-        new UEModel(objectName, dto, options).Save(ar);
-        return [new ExportFile("uemodel", ar.GetBuffer())];
+        if (options.NaniteMeshFormat == ENaniteMeshFormat.NaniteSeparate 
+            && dto.LODs.Any(l => l.IsNanite) 
+            && dto.LODs.Any(l => !l.IsNanite))
+        {
+            return
+            [
+                dto.WithLods(lod => !lod.IsNanite, () => Save(objectName, dto, options)),
+                dto.WithLods(lod => lod.IsNanite, () => Save(objectName, dto, options, "_Nanite")),
+            ];
+        }
+
+        return [Save(objectName, dto, options)];
     }
 
     public IReadOnlyList<ExportFile> BuildSkeleton(string objectName, ExportOptions options, SkeletonDto dto)
@@ -30,5 +50,18 @@ public sealed class UEFormatMeshFormat : IMeshExportFormat
         new UEModel(objectName, dto, options).Save(ar);
         return [new ExportFile("uemodel", ar.GetBuffer())];
     }
-}
 
+    private static ExportFile Save(string objectName, StaticMeshDto dto, ExportOptions options, string? suffix = null)
+    {
+        using var ar = new FArchiveWriter();
+        new UEModel(objectName, dto, options).Save(ar);
+        return new ExportFile("uemodel", ar.GetBuffer(), suffix);
+    }
+
+    private static ExportFile Save(string objectName, SkeletalMeshDto dto, ExportOptions options, string? suffix = null)
+    {
+        using var ar = new FArchiveWriter();
+        new UEModel(objectName, dto, options).Save(ar);
+        return new ExportFile("uemodel", ar.GetBuffer(), suffix);
+    }
+}

--- a/CUE4Parse-Conversion/Options/ENaniteMeshFormat.cs
+++ b/CUE4Parse-Conversion/Options/ENaniteMeshFormat.cs
@@ -12,4 +12,6 @@ public enum ENaniteMeshFormat
     NaniteFirst,
     [Description("Normal LODs first, then Nanite LOD")]
     NaniteLast,
+    [Description("Export Nanite as Separate File")]
+    NaniteSeparate,
 }


### PR DESCRIPTION
- Adds a `NaniteSeparate` option to `ENaniteMeshFormat`, allowing UEFormat to expore nanite meshes as separate files