### PR TITLE
build(natives): fix ACL build with Clang 19 and newer

### DIFF
--- a/CUE4Parse-Natives/CMakeLists.txt
+++ b/CUE4Parse-Natives/CMakeLists.txt
@@ -3,6 +3,15 @@ project(CUE4Parse-Natives CXX)
 
 set(CMAKE_CXX_STANDARD 11)
 
+include(CheckCXXCompilerFlag)
+
+# Clang 19+ (incl. Apple Clang shipping with Xcode 16 and newer) turns
+# -Wmissing-template-arg-list-after-template-kw into an error for the
+# `x.template decompress_tracks(...)` pattern used throughout the vendored ACL
+# headers. Probe the positive form of the flag (GCC silently accepts unknown
+# -Wno-* options, so probing the negative form yields false positives).
+check_cxx_compiler_flag("-Wmissing-template-arg-list-after-template-kw" HAS_MISSING_TEMPLATE_ARG_LIST_WARNING)
+
 
 if (EXISTS "${PROJECT_SOURCE_DIR}/ACL/external/acl/includes")
     set(WITH_ACL 1)
@@ -32,6 +41,10 @@ include_directories("${PROJECT_SOURCE_DIR}/common")
 
 add_library("${PROJECT_NAME}" SHARED ${SOURCES})
 set_target_properties("${PROJECT_NAME}" PROPERTIES PREFIX "")
+
+if (HAS_MISSING_TEMPLATE_ARG_LIST_WARNING)
+    target_compile_options("${PROJECT_NAME}" PRIVATE -Wno-missing-template-arg-list-after-template-kw)
+endif()
 
 # Oodle
 if (WITH_Oodle)


### PR DESCRIPTION
### Problem

`CUE4Parse-Natives` does not compile with any Clang 19+ toolchain, which includes the Apple Clang shipped with Xcode 16 and newer. Building current `master` (7c1ba97) on macOS 26 arm64 with Apple clang 21.0.0:

```
.../CUE4Parse-Natives/ACL/external/acl/includes/acl/decompression/impl/decompress.impl.h:174:39:
  error: a template argument list is expected after a name prefixed by the template keyword
         [-Wmissing-template-arg-list-after-template-kw]
.../decompress.impl.h:180:38: error: (same)
.../decompress.impl.h:189:38: error: (same)
make[2]: *** [CMakeFiles/CUE4Parse-Natives.dir/ACL/ACL.cpp.o] Error 1
make: *** [all] Error 2
```

Clang 19 promoted `-Wmissing-template-arg-list-after-template-kw` to an error by default, and the vendored ACL headers use the `x.template decompress_tracks(...)` pattern that triggers it. The result is that no native library is produced at all on a current macOS toolchain, so ACL-compressed animations fall back to unsupported.

### Change

Suppress the diagnostic, scoped to the `CUE4Parse-Natives` target.

The probe deliberately tests the **positive** form of the flag rather than `-Wno-...`: GCC accepts unknown `-Wno-*` options silently, so probing the negative form would report success even on compilers that have never heard of this warning. With the positive-form probe, the flag is added only where the warning actually exists, and every other toolchain is untouched by construction.

### Verification

macOS 26 arm64, Apple clang 21.0.0 (clang-2100.1.1.101), CMake `Release`, ACL submodule initialised:

| | Result |
|---|---|
| `master` unmodified | ❌ `Error 1` — no library produced |
| with this patch | ✅ `Performing Test HAS_MISSING_TEMPLATE_ARG_LIST_WARNING - Success` → `CUE4Parse-Natives.dylib: Mach-O 64-bit dynamically linked shared library arm64`, `_nReadACLData` exported |

This is a build-only change; no source or behaviour is affected.
