### PR TITLE
fix(textures): use managed decoders for BC6H/BC7/ETC off Windows

### DIFF
--- a/CUE4Parse-Conversion/Textures/TextureDecoder.cs
+++ b/CUE4Parse-Conversion/Textures/TextureDecoder.cs
@@ -20,15 +20,8 @@ namespace CUE4Parse_Conversion.Textures;
 public static class TextureDecoder
 {
 
-    /// <summary>
-    /// Route BC6H/BC7/ETC decoding through the managed AssetRipper decoders instead of Detex.
-    /// <para>
-    /// Detex ships as an embedded Windows PE (<see cref="BC.DetexHelper.DLL_NAME"/>), so on any
-    /// non-Windows host it can never initialize and those formats would throw
-    /// "Detex decompression failed: not initialized". Default to the managed path there.
-    /// </para>
-    /// </summary>
-    public static bool UseAssetRipperTextureDecoder { get; set; } = !OperatingSystem.IsWindows();
+    public static bool UseAssetRipperTextureDecoder { get; set; } = false;
+    internal static readonly bool IsWindows = OperatingSystem.IsWindows(); 
 
     public static CTexture? Decode(this UTexture texture, int maxMipSize, ETexturePlatform platform = ETexturePlatform.DesktopMobile) => texture.DecodeMip(texture.GetMipIndexByMaxSize(maxMipSize), platform);
     public static CTexture? Decode(this UTexture texture, ETexturePlatform platform = ETexturePlatform.DesktopMobile) => texture.DecodeMip(texture.GetFirstMipIndex(), platform);
@@ -410,7 +403,7 @@ public static class TextureDecoder
                 colorType = EPixelFormat.PF_B8G8R8A8;
                 break;
             case EPixelFormat.PF_BC6H:
-                if (UseAssetRipperTextureDecoder)
+                if (UseAssetRipperTextureDecoder || !IsWindows)
                 {
                     Bc6h.Decompress<ColorRGBA<byte>, byte>(bytes, sizeX, sizeY, false, out data);
                     colorType = EPixelFormat.PF_R8G8B8A8;
@@ -424,14 +417,14 @@ public static class TextureDecoder
                 }
                 break;
             case EPixelFormat.PF_BC7:
-                if (UseAssetRipperTextureDecoder)
+                if (UseAssetRipperTextureDecoder || !IsWindows)
                     Bc7.Decompress<ColorRGBA<byte>, byte>(bytes, sizeX, sizeY, out data);
                 else
                     data = DetexHelper.DecodeDetexLinear(bytes, sizeX, sizeY * sizeZ, false, DetexTextureFormat.DETEX_TEXTURE_FORMAT_BPTC, DetexPixelFormat.DETEX_PIXEL_FORMAT_BGRA8);
                 colorType = EPixelFormat.PF_B8G8R8A8;
                 break;
             case EPixelFormat.PF_ETC1:
-                if (UseAssetRipperTextureDecoder)
+                if (UseAssetRipperTextureDecoder || !IsWindows)
                 {
                     EtcDecoder.DecompressETC<ColorRGBA<byte>, byte>(bytes, sizeX, sizeY, out data);
                     colorType = EPixelFormat.PF_R8G8B8A8;
@@ -443,7 +436,7 @@ public static class TextureDecoder
                 }
                 break;
             case EPixelFormat.PF_ETC2_RGB:
-                if (UseAssetRipperTextureDecoder)
+                if (UseAssetRipperTextureDecoder || !IsWindows)
                 {
                     EtcDecoder.DecompressETC2<ColorRGBA<byte>, byte>(bytes, sizeX, sizeY, out data);
                     colorType = EPixelFormat.PF_R8G8B8A8;
@@ -455,7 +448,7 @@ public static class TextureDecoder
                 }
                 break;
             case EPixelFormat.PF_ETC2_RGBA:
-                if (UseAssetRipperTextureDecoder)
+                if (UseAssetRipperTextureDecoder || !IsWindows)
                 {
                     EtcDecoder.DecompressETC2A8<ColorRGBA<byte>, byte>(bytes, sizeX, sizeY, out data);
                     colorType = EPixelFormat.PF_R8G8B8A8;

--- a/CUE4Parse-Conversion/Textures/TextureDecoder.cs
+++ b/CUE4Parse-Conversion/Textures/TextureDecoder.cs
@@ -2,6 +2,7 @@ using System.Buffers;
 using System.Runtime.InteropServices;
 using AssetRipper.TextureDecoder.Astc;
 using AssetRipper.TextureDecoder.Bc;
+using AssetRipper.TextureDecoder.Etc;
 using AssetRipper.TextureDecoder.Pvrtc;
 using AssetRipper.TextureDecoder.Rgb.Formats;
 using CUE4Parse_Conversion.Textures.ASTC;
@@ -19,7 +20,15 @@ namespace CUE4Parse_Conversion.Textures;
 public static class TextureDecoder
 {
 
-    public static bool UseAssetRipperTextureDecoder { get; set; } = false;
+    /// <summary>
+    /// Route BC6H/BC7/ETC decoding through the managed AssetRipper decoders instead of Detex.
+    /// <para>
+    /// Detex ships as an embedded Windows PE (<see cref="BC.DetexHelper.DLL_NAME"/>), so on any
+    /// non-Windows host it can never initialize and those formats would throw
+    /// "Detex decompression failed: not initialized". Default to the managed path there.
+    /// </para>
+    /// </summary>
+    public static bool UseAssetRipperTextureDecoder { get; set; } = !OperatingSystem.IsWindows();
 
     public static CTexture? Decode(this UTexture texture, int maxMipSize, ETexturePlatform platform = ETexturePlatform.DesktopMobile) => texture.DecodeMip(texture.GetMipIndexByMaxSize(maxMipSize), platform);
     public static CTexture? Decode(this UTexture texture, ETexturePlatform platform = ETexturePlatform.DesktopMobile) => texture.DecodeMip(texture.GetFirstMipIndex(), platform);
@@ -422,16 +431,40 @@ public static class TextureDecoder
                 colorType = EPixelFormat.PF_B8G8R8A8;
                 break;
             case EPixelFormat.PF_ETC1:
-                data = DetexHelper.DecodeDetexLinear(bytes, sizeX, sizeY, false, DetexTextureFormat.DETEX_TEXTURE_FORMAT_ETC1, DetexPixelFormat.DETEX_PIXEL_FORMAT_BGRA8);
-                colorType = EPixelFormat.PF_B8G8R8A8;
+                if (UseAssetRipperTextureDecoder)
+                {
+                    EtcDecoder.DecompressETC<ColorRGBA<byte>, byte>(bytes, sizeX, sizeY, out data);
+                    colorType = EPixelFormat.PF_R8G8B8A8;
+                }
+                else
+                {
+                    data = DetexHelper.DecodeDetexLinear(bytes, sizeX, sizeY, false, DetexTextureFormat.DETEX_TEXTURE_FORMAT_ETC1, DetexPixelFormat.DETEX_PIXEL_FORMAT_BGRA8);
+                    colorType = EPixelFormat.PF_B8G8R8A8;
+                }
                 break;
             case EPixelFormat.PF_ETC2_RGB:
-                data = DetexHelper.DecodeDetexLinear(bytes, sizeX, sizeY, false, DetexTextureFormat.DETEX_TEXTURE_FORMAT_ETC2, DetexPixelFormat.DETEX_PIXEL_FORMAT_BGRA8);
-                colorType = EPixelFormat.PF_B8G8R8A8;
+                if (UseAssetRipperTextureDecoder)
+                {
+                    EtcDecoder.DecompressETC2<ColorRGBA<byte>, byte>(bytes, sizeX, sizeY, out data);
+                    colorType = EPixelFormat.PF_R8G8B8A8;
+                }
+                else
+                {
+                    data = DetexHelper.DecodeDetexLinear(bytes, sizeX, sizeY, false, DetexTextureFormat.DETEX_TEXTURE_FORMAT_ETC2, DetexPixelFormat.DETEX_PIXEL_FORMAT_BGRA8);
+                    colorType = EPixelFormat.PF_B8G8R8A8;
+                }
                 break;
             case EPixelFormat.PF_ETC2_RGBA:
-                data = DetexHelper.DecodeDetexLinear(bytes, sizeX, sizeY, false, DetexTextureFormat.DETEX_TEXTURE_FORMAT_ETC2_EAC, DetexPixelFormat.DETEX_PIXEL_FORMAT_BGRA8);
-                colorType = EPixelFormat.PF_B8G8R8A8;
+                if (UseAssetRipperTextureDecoder)
+                {
+                    EtcDecoder.DecompressETC2A8<ColorRGBA<byte>, byte>(bytes, sizeX, sizeY, out data);
+                    colorType = EPixelFormat.PF_R8G8B8A8;
+                }
+                else
+                {
+                    data = DetexHelper.DecodeDetexLinear(bytes, sizeX, sizeY, false, DetexTextureFormat.DETEX_TEXTURE_FORMAT_ETC2_EAC, DetexPixelFormat.DETEX_PIXEL_FORMAT_BGRA8);
+                    colorType = EPixelFormat.PF_B8G8R8A8;
+                }
                 break;
             case EPixelFormat.PF_ETC2_R11:
             case EPixelFormat.PF_ETC2_R11_EAC:


### PR DESCRIPTION
### Problem

`DetexHelper` loads Detex from an embedded native **Windows** DLL (`CUE4Parse_Conversion.Resources.Detex.dll`, `DLL_NAME = "Detex.dll"`), so on macOS and Linux `Instance` stays `null` and every affected texture throws:

```
Exception: Detex decompression failed: not initialized
```

That covers `PF_BC6H`, `PF_BC7`, `PF_ETC1`, `PF_ETC2_RGB` and `PF_ETC2_RGBA`. The only workaround today is the one #100 documents for Linux — clone detex, edit `Makefile.conf` and `detex.h`, build it by hand, and ship the result alongside the app.

`UseAssetRipperTextureDecoder` already exists and already covers BC6H/BC7, but it defaults to `false`, and the ETC formats have no managed branch at all.

### Change

1. `UseAssetRipperTextureDecoder` now defaults to `!OperatingSystem.IsWindows()`.
   Windows behaviour is unchanged — it still evaluates to `false` and still goes through Detex. The property stays public and settable in both directions, so anyone shipping their own detex build on Linux/macOS can set it back to `false`.
2. Added the missing AssetRipper branches for `PF_ETC1` / `PF_ETC2_RGB` / `PF_ETC2_RGBA` using `EtcDecoder.DecompressETC` / `DecompressETC2` / `DecompressETC2A8`, structured exactly like the existing BC6H/BC7 branches (managed path yields `PF_R8G8B8A8`, Detex path `PF_B8G8R8A8`).

No new dependency: `AssetRipper.TextureDecoder` is already referenced and `EtcDecoder` ships in the same package.

### Verification

macOS 26 arm64, .NET 10, built against `master` (7c1ba97). DXT1, DXT5, BC4, BC5, BC6H, BC7, ASTC_4x4 and ETC2_RGB all decode; before the change the BC6H, BC7 and ETC cases threw.

### One thing worth your call

I have not diffed managed vs. Detex output byte-for-byte. For BC6H/BC7 the managed decoder was already the sanctioned alternative, so this only changes *which* of two existing paths non-Windows hosts pick by default; ETC is new ground.

If you would rather not change a default at all, an equally good shape would be to keep it `false` and fall back to the managed decoder only when `DetexHelper` fails to initialise. Happy to rework it that way — just say which you prefer.

Refs #100
