### PR TITLE
fix(textures): report BC7 as RGBA on the managed decoder path

### DIFF
--- a/CUE4Parse-Conversion/Textures/TextureDecoder.cs
+++ b/CUE4Parse-Conversion/Textures/TextureDecoder.cs
@@ -421,10 +421,6 @@ public static class TextureDecoder
             case EPixelFormat.PF_BC7:
                 if (UseAssetRipperTextureDecoder || !IsWindows)
                 {
-                    // This branch emits ColorRGBA, so the result has to be reported as RGBA.
-                    // Reporting BGRA swapped red and blue in every BC7 texture decoded here,
-                    // which is every platform other than Windows. The ETC branches below
-                    // already set the colour type per branch; BC7 was the sole outlier.
                     Bc7.Decompress<ColorRGBA<byte>, byte>(bytes, sizeX, sizeY, out data);
                     colorType = EPixelFormat.PF_R8G8B8A8;
                 }

--- a/CUE4Parse-Conversion/Textures/TextureDecoder.cs
+++ b/CUE4Parse-Conversion/Textures/TextureDecoder.cs
@@ -420,10 +420,19 @@ public static class TextureDecoder
                 break;
             case EPixelFormat.PF_BC7:
                 if (UseAssetRipperTextureDecoder || !IsWindows)
+                {
+                    // This branch emits ColorRGBA, so the result has to be reported as RGBA.
+                    // Reporting BGRA swapped red and blue in every BC7 texture decoded here,
+                    // which is every platform other than Windows. The ETC branches below
+                    // already set the colour type per branch; BC7 was the sole outlier.
                     Bc7.Decompress<ColorRGBA<byte>, byte>(bytes, sizeX, sizeY, out data);
+                    colorType = EPixelFormat.PF_R8G8B8A8;
+                }
                 else
+                {
                     data = DetexHelper.DecodeDetexLinear(bytes, sizeX, sizeY * sizeZ, false, DetexTextureFormat.DETEX_TEXTURE_FORMAT_BPTC, DetexPixelFormat.DETEX_PIXEL_FORMAT_BGRA8);
-                colorType = EPixelFormat.PF_B8G8R8A8;
+                    colorType = EPixelFormat.PF_B8G8R8A8;
+                }
                 break;
             case EPixelFormat.PF_ETC1:
                 if (UseAssetRipperTextureDecoder || !IsWindows)


### PR DESCRIPTION
The managed BC7 branch decodes into `ColorRGBA<byte>`, but `colorType` was assigned
outside the if/else and unconditionally set to `PF_B8G8R8A8`. Every BC7 texture
decoded through that branch therefore comes out with red and blue swapped.

```csharp
case EPixelFormat.PF_BC7:
    if (UseAssetRipperTextureDecoder || !IsWindows)
        Bc7.Decompress<ColorRGBA<byte>, byte>(bytes, sizeX, sizeY, out data);  // RGBA
    else
        data = DetexHelper.DecodeDetexLinear(..., DETEX_PIXEL_FORMAT_BGRA8);   // BGRA
    colorType = EPixelFormat.PF_B8G8R8A8;   // <- wrong for the branch above
    break;
```

The condition is `UseAssetRipperTextureDecoder || !IsWindows`, so this affects every
non-Windows host. BC7 is one of the most common formats in modern UE titles.

This looks like an oversight rather than a deliberate choice: every other
`ColorRGBA` branch in the same switch already reports `PF_R8G8B8A8` per branch —
BC6H immediately above it, ETC1/ETC2 immediately below. BC7 was the only one
assigning the colour type outside the branches. The fix moves the assignment
inside, leaving the Detex path reporting BGRA as before.

### How it was found

Not by reading the code. I cook the same checkerboard-plus-gradient image into
uncompressed RGBA8, BC1 and BC7, then compare decoded output against the
generating algorithm pixel by pixel. BC1 landed inside tolerance; BC7 came out at
a mean absolute error of 85/255. Lossy compression does not produce an error of
that magnitude — only a structural mistake does.

The pattern matters for this kind of bug: a checkerboard exposes row-order and
block-offset errors, and a horizontal gradient exposes channel-order errors. A
flat colour or noise would hide both, and so would a greyscale fixture.

### Verification

macOS arm64, .NET 10. Before: BC7 mean absolute error 85/255 against the
generating algorithm. After: within the same tolerance as BC1/BC5. Uncompressed
RGBA8 is exact (4096/4096 pixels) in both cases, which rules out the comparison
harness itself.