### PR TITLE
fix(textures): decode virtual texture layers separately

### DIFF
--- a/CUE4Parse-Conversion/Exporters/TextureExporter.cs
+++ b/CUE4Parse-Conversion/Exporters/TextureExporter.cs
@@ -43,6 +43,21 @@ public sealed class TextureExporter(UTexture texture) : ExporterBase(texture)
         {
             ct.ThrowIfCancellationRequested();
 
+            // A multi-layer virtual texture is several independent images (a lightmap is three
+            // directional-coefficient layers plus sky occlusion), so write one file per layer.
+            // Decoding it down to a single image would silently drop everything but layer 0.
+            if (texture.PlatformData is { VTData: { NumLayers: > 1 } vtData } && vtData.IsInitialized())
+            {
+                var layers = TextureDecoder.DecodeVirtualTextureLayers(texture, vtData, index);
+                for (var layer = 0; layer < layers.Length; layer++)
+                {
+                    var layerData = layers[layer].Encode(Session.Options, out var layerExt);
+                    files.Add(new ExportFile(layerExt, layerData,
+                        (all ? $"_MIP{index}" : "") + $"_LAYER{layer}"));
+                }
+                return;
+            }
+
             var decoded = texture.DecodeMip(index, Session.Options.TexturePlatform);
             if (decoded == null)
             {

--- a/CUE4Parse-Conversion/Textures/TextureDecoder.cs
+++ b/CUE4Parse-Conversion/Textures/TextureDecoder.cs
@@ -26,7 +26,7 @@ public static class TextureDecoder
     public static CTexture? Decode(this UTexture texture, FTexture2DMipMap? mip, ETexturePlatform platform = ETexturePlatform.DesktopMobile, int zLayer = 0)
     {
         if (texture.PlatformData is { FirstMipToSerialize: >= 0, VTData: { } vt } && vt.IsInitialized())
-            return DecodeVT(texture, vt);
+            return DecodeVirtualTexture(texture, vt);
 
         if (mip == null)
             return null;
@@ -48,7 +48,7 @@ public static class TextureDecoder
     public static CTexture? DecodeMip(this UTexture texture, int mipIndex, ETexturePlatform platform = ETexturePlatform.DesktopMobile, int zLayer = 0)
     {
         if (texture.PlatformData is { FirstMipToSerialize: >= 0, VTData: { } vt } && vt.IsInitialized())
-            return DecodeVT(texture, vt, mipIndex);
+            return DecodeVirtualTexture(texture, vt, mipIndex);
 
         var mip = texture.GetMip(mipIndex);
         if (mip == null)
@@ -87,7 +87,39 @@ public static class TextureDecoder
         return 0;
     }
 
-    private static CTexture DecodeVT(UTexture texture, FVirtualTextureBuiltData vt, int mip = -1)
+    /// <summary>
+    /// Decode a virtual texture, returning <b>one image per layer</b>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A virtual texture's layers are independent images, not channels of one image:
+    /// a UE lightmap is three directional-coefficient layers plus a sky-occlusion layer,
+    /// and those layers routinely use different pixel formats (DXT5 + B8G8R8A8).
+    /// </para>
+    /// <para>
+    /// This used to decode every layer into a single shared buffer, which broke two ways:
+    /// layers whose formats differed threw "multiple pixelformats/colortypes in a single
+    /// virtual image is not supported", and layers whose formats matched silently
+    /// overwrote one another so only the last layer survived. Decoding per layer fixes both.
+    /// </para>
+    /// </remarks>
+    public static CTexture[] DecodeVirtualTextureLayers(UTexture texture, FVirtualTextureBuiltData vt, int mip = -1)
+    {
+        var layers = new CTexture[vt.NumLayers];
+        for (uint layer = 0; layer < vt.NumLayers; layer++)
+            layers[layer] = DecodeVTLayer(texture, vt, layer, mip);
+
+        return layers;
+    }
+
+    /// <summary>
+    /// Decode a virtual texture down to a single image. Multi-layer textures yield layer 0;
+    /// use <see cref="DecodeVirtualTextureLayers"/> to get all of them.
+    /// </summary>
+    public static CTexture DecodeVirtualTexture(UTexture texture, FVirtualTextureBuiltData vt, int mip = -1)
+        => DecodeVTLayer(texture, vt, 0, mip);
+
+    private static CTexture DecodeVTLayer(UTexture texture, FVirtualTextureBuiltData vt, uint layer, int mip = -1)
     {
         unsafe
         {
@@ -120,7 +152,6 @@ public static class TextureDecoder
             var tileRowBytes = 0;
             var result = Span<byte>.Empty;
 
-            for (uint layer = 0; layer < vt.NumLayers; layer++)
             {
                 var layerFormat = vt.LayerTypes[layer];
                 if (!PixelFormatUtils.PixelFormats.TryGetValue(layerFormat, out var formatInfo) || !formatInfo.Supported || formatInfo.BlockBytes == 0)
@@ -198,7 +229,10 @@ public static class TextureDecoder
                         result = new Span<byte>(pixelDataPtr, imageBytes);
                     }
                     else if (colorType != tileColorType)
-                        throw new NotSupportedException("multiple pixelformats/colortypes in a single virtual image is not supported");
+                        // Every tile in a layer decodes through the same format info, so this is an
+                        // invariant check rather than a real limitation. (Layers with differing
+                        // formats are fine now: each one is decoded into its own image.)
+                        throw new NotSupportedException($"tiles of layer {layer} decoded to different color types ({colorType} and {tileColorType})");
 
                     for (int i = 0; i < tileSize; i++)
                     {
@@ -216,10 +250,21 @@ public static class TextureDecoder
 
                 ArrayPool<byte>.Shared.Return(layerData);
             }
-            var managedData = GetSliceData((byte*)pixelDataPtr, bitmapWidth, bitmapHeight, bytesPerPixel).ToArray();
-            NativeMemory.Free(pixelDataPtr);
 
-            return new CTexture(bitmapWidth, bitmapHeight, colorType, managedData);
+            if (pixelDataPtr is null)
+                // No tile in this mip carried data, so nothing was ever allocated. Reading from the
+                // null pointer below would be an access violation rather than a diagnosable error.
+                throw new ParserException($"Virtual texture layer {layer} has no tile data at level {level}");
+
+            try
+            {
+                var managedData = GetSliceData((byte*) pixelDataPtr, bitmapWidth, bitmapHeight, bytesPerPixel).ToArray();
+                return new CTexture(bitmapWidth, bitmapHeight, colorType, managedData);
+            }
+            finally
+            {
+                NativeMemory.Free(pixelDataPtr);
+            }
         }
     }
 


### PR DESCRIPTION
A virtual texture's layers are independent images, not channels of one image. A UE
lightmap is three directional-coefficient layers plus a sky-occlusion layer, and
those layers routinely use different pixel formats — `[DXT5, DXT5, DXT5, B8G8R8A8]`
is the shape I see across a whole title.

`DecodeVT` loops over every layer but allocates a single output buffer, and the
write offset is computed from tile coordinates alone:

```csharp
var offset = tileX * bytesPerPixel + (tileY + i) * rowBytes;   // no layer term
srcSpan.CopyTo(result[offset..]);
```

So it breaks two ways:

1. **Layers with differing formats throw** — `"multiple pixelformats/colortypes in a
   single virtual image is not supported"`.
2. **Layers with matching formats do not throw**, but each layer overwrites the
   previous one at the same addresses. Only the last layer survives; the earlier
   ones are lost silently.

The second one is the dangerous half. The file opens, looks plausible, and is
missing two thirds of its data.

### Measurements

A real UE 5.4 title, 2000 packages, 260 lightmap virtual textures:

| | before | after |
|---|---|---|
| decoded | 22 (each holding only its last layer) | 260 |
| threw | 238 | 0 |

Byte-for-byte confirmation of the silent case: the single `VirtualTexture0_12_HQ.png`
produced before this change has the same sha256 as `VirtualTexture0_12_HQ_LAYER2.png`
produced after it (`e26cb71a4588`). `_LAYER0` and `_LAYER1` were never written.

Layer shapes observed in that title: `[DXT5,DXT5,DXT5,B8G8R8A8]`, `[DXT1,DXT1,B8G8R8A8]`,
`[DXT5,DXT5,DXT5]`, `[DXT1,DXT1]` — the first two hit case 1, the last two hit case 2.

### Changes

- `DecodeVirtualTextureLayers` returns one `CTexture` per layer.
- `DecodeVirtualTexture` keeps the single-image shape and returns layer 0, so
  `Decode`/`DecodeMip` behave as before for single-layer textures.
- `TextureExporter` writes one file per layer with a `_LAYER{n}` suffix when
  `NumLayers > 1`. Single-layer textures keep their existing filenames.

Two latent problems in the same function are fixed on the way through: a mip with
no valid tile data dereferenced a null pointer instead of raising a diagnosable
error, and the native buffer leaked whenever decoding threw.

### Testing

Multi-layer VT data can only be produced by an editor bake (lightmaps need
Lightmass), so there is no way to cook a fixture headlessly, and shipping game
data is not redistributable. I build a minimal 1-mip/1-tile virtual texture in
memory instead and assert: layers with differing formats all decode; each layer
keeps its own pixels; same-format layers do not overwrite one another; single-layer
behaviour is unchanged; the single-image path returns layer 0.

Happy to reshape that into whatever fits `CUE4Parse.Tests` if you would like the
fixture upstream too.