### PR TITLE
Sanitise USD joint paths — illegal bone names silently cost you the entire skeleton

### DIFF
--- a/CUE4Parse-Conversion/Writers/USD/Usd.cs
+++ b/CUE4Parse-Conversion/Writers/USD/Usd.cs
@@ -226,7 +226,11 @@ public sealed class UsdPrim(string typeName, string name, UsdPrimSpecifier speci
     public static UsdPrim Over(string typeName, string name) => new(typeName, name, UsdPrimSpecifier.Over);
     public static UsdPrim Class(string typeName, string name) => new(typeName, name, UsdPrimSpecifier.Class);
 
-    private static string SanitizeIdentifier(string name)
+    /// <summary>Coerces <paramref name="name"/> into a legal USD identifier, returning it
+    /// unchanged when it already is one.</summary>
+    /// <remarks>Also used for the joint paths in <c>UsdExtensions.ToSkelRoot</c>, which are
+    /// built from bone names rather than from prims but must satisfy the same grammar.</remarks>
+    internal static string SanitizeIdentifier(string name)
     {
         if (name.Length == 0) return "_unnamed";
 

--- a/CUE4Parse-Conversion/Writers/USD/UsdExtensions.cs
+++ b/CUE4Parse-Conversion/Writers/USD/UsdExtensions.cs
@@ -72,6 +72,8 @@ public static class UsdExtensions
         var root = UsdPrim.Def("SkelRoot", dto.Name);
         var skeletonPrim = UsdPrim.Def("Skeleton", dto.SkeletonName ?? root.Name);
 
+        var names = ResolveJointNames(dto.Bones);
+
         var joints = new UsdValue[dto.Bones.Length];
         var rest = new UsdValue[joints.Length];
         var bind = new Matrix4x4[joints.Length]; // world-space accumulated
@@ -79,7 +81,7 @@ public static class UsdExtensions
         {
             var bone = dto.Bones[i];
 
-            var path = bone.ParentIndex >= 0 ? $"{joints[bone.ParentIndex].RawValue}/{bone.Name}" : bone.Name;
+            var path = bone.ParentIndex >= 0 ? $"{joints[bone.ParentIndex].RawValue}/{names[i]}" : names[i];
             joints[i] = UsdValue.Token(path);
 
             var local = bone.Transform.ToMatrix4x4();
@@ -92,8 +94,87 @@ public static class UsdExtensions
         skeletonPrim.Add(UsdAttribute.Uniform("matrix4d[]", "restTransforms", UsdValue.Array(rest)));
         skeletonPrim.Add(UsdAttribute.Uniform("matrix4d[]", "bindTransforms", UsdValue.Array(bind.Select(x => UsdValue.From(x)))));
 
+        // Renaming is lossy — Bip001-L-Clavicle and Bip001_L_Clavicle collapse to the same
+        // identifier — so keep the engine's own spelling when it had to be changed. Only
+        // emitted for skeletons that were actually renamed; the overwhelming majority are not.
+        for (var i = 0; i < names.Length; i++)
+        {
+            if (names[i] == dto.Bones[i].Name) continue;
+            skeletonPrim.Add(UsdAttribute.CustomUniform("string[]", "unrealJointNames",
+                UsdValue.Array(dto.Bones.Select(b => UsdValue.String(b.Name)))));
+            break;
+        }
+
         root.Add(skeletonPrim);
         return root;
+    }
+
+    /// <summary>
+    /// Maps UE bone names onto names that are legal as USD prim identifiers, i.e.
+    /// <c>[A-Za-z_][A-Za-z0-9_]*</c>.
+    /// </summary>
+    /// <remarks>
+    /// UE puts no such restriction on bone names, and skeletons authored in 3ds Max Biped
+    /// routinely look like <c>Bip001-L-Clavicle</c>. Writing that into the joints array does not
+    /// produce a slightly odd name, it produces an <em>ill-formed SdfPath</em>, and consumers
+    /// reject the whole skeleton over it: Blender logs
+    /// <c>joint order array contains invalid or duplicated paths</c> and imports the mesh with no
+    /// armature and no animation. Nothing fails loudly — the rig is just missing.
+    /// <para>
+    /// Substitution alone is not enough, because it can manufacture the other half of that same
+    /// error message. Real skeletons carry <c>steering-wheel</c> and <c>steering_wheel</c> as
+    /// siblings; mapping both to <c>steering_wheel</c> yields duplicate paths and the same
+    /// rejection. So names are disambiguated within their sibling group, which is exactly the
+    /// scope USD requires uniqueness in.
+    /// </para>
+    /// <para>
+    /// Names that are already legal are reserved first, before any substitution is assigned.
+    /// Otherwise a bone that was perfectly fine could be pushed to <c>name_1</c> merely because a
+    /// sibling was malformed, and a fix for 16 files would churn the names in thousands.
+    /// </para>
+    /// </remarks>
+    private static string[] ResolveJointNames(MeshBoneDto[] bones)
+    {
+        var names = new string[bones.Length];
+        var taken = new Dictionary<int, HashSet<string>>();
+
+        HashSet<string> Siblings(int parentIndex)
+        {
+            if (!taken.TryGetValue(parentIndex, out var set))
+                taken[parentIndex] = set = new HashSet<string>(StringComparer.Ordinal);
+            return set;
+        }
+
+        // Pass 1 — claim the names that need no help. SanitizeIdentifier returns its input
+        // unchanged exactly when the name is already valid, so this needs no second predicate.
+        // A name that is legal but already claimed by a sibling is left for pass 2: a duplicate
+        // path is rejected on exactly the same grounds as a malformed one, so it cannot be
+        // waved through just because both spellings happen to be legal.
+        for (var i = 0; i < bones.Length; i++)
+        {
+            var name = bones[i].Name;
+            if (UsdPrim.SanitizeIdentifier(name) != name) continue;
+            if (!Siblings(bones[i].ParentIndex).Add(name)) continue;
+            names[i] = name;
+        }
+
+        // Pass 2 — everything left over, disambiguated against the claims from pass 1 and
+        // against each other.
+        for (var i = 0; i < bones.Length; i++)
+        {
+            if (names[i] is not null) continue;
+
+            var siblings = Siblings(bones[i].ParentIndex);
+            var sanitized = UsdPrim.SanitizeIdentifier(bones[i].Name);
+
+            var candidate = sanitized;
+            for (var counter = 1; !siblings.Add(candidate); counter++)
+                candidate = $"{sanitized}_{counter}";
+
+            names[i] = candidate;
+        }
+
+        return names;
     }
 
     public static UsdPrim ToMeshPrim(this BrushComponentDto brush)

--- a/CUE4Parse.Tests/CUE4Parse.Tests.csproj
+++ b/CUE4Parse.Tests/CUE4Parse.Tests.csproj
@@ -24,6 +24,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\CUE4Parse\CUE4Parse.csproj" />
+    <ProjectReference Include="..\CUE4Parse-Conversion\CUE4Parse-Conversion.csproj" />
   </ItemGroup>
 
 </Project>

--- a/CUE4Parse.Tests/UsdJointPathTests.cs
+++ b/CUE4Parse.Tests/UsdJointPathTests.cs
@@ -1,0 +1,204 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using CUE4Parse.UE4.Assets.Exports.Animation;
+using CUE4Parse.UE4.Objects.Core.Math;
+using CUE4Parse.UE4.Objects.UObject;
+using CUE4Parse_Conversion.Dto;
+using CUE4Parse_Conversion.Writers.USD;
+
+namespace CUE4Parse.Tests;
+
+/// <summary>
+/// Joint paths have to be legal SdfPaths. UE bone names are under no such obligation.
+/// </summary>
+/// <remarks>
+/// Found on shipped content: skeletons authored in 3ds Max Biped carry names like
+/// <c>Bip001-L-Clavicle</c>. Writing those into the joints array yields ill-formed paths, and
+/// Blender responds by dropping the entire skeleton — mesh, materials and textures all import,
+/// the armature comes in empty, and nothing raises. Measured on two titles: 16 of 456 skeletons
+/// in one, 1 of 1,436 in the other.
+///
+/// So what is pinned here is not "is something being substituted" but that the substitution
+/// cannot produce the other half of that same error message. The "duplicated" in Blender's
+/// warning is reachable: a real skeleton carries <c>steering-wheel</c> and <c>steering_wheel</c>
+/// as siblings.
+/// </remarks>
+public class UsdJointPathTests
+{
+    private static readonly Regex LegalIdentifier = new(@"^[A-Za-z_][A-Za-z0-9_]*$", RegexOptions.Compiled);
+
+    /// <summary>(name, parent index) pairs into an exportable skeleton. Parents precede children,
+    /// as they do in a UE reference skeleton.</summary>
+    private static SkeletonDto Skeleton(params (string Name, int Parent)[] bones)
+    {
+        var info = bones.Select(b => new FMeshBoneInfo(new FName(b.Name), b.Parent)).ToArray();
+        var pose = bones.Select(_ => new FTransform(FQuat.Identity, FVector.ZeroVector, FVector.OneVector)).ToArray();
+
+        return new SkeletonDto(new USkeleton
+        {
+            Name = "TestSkeleton",
+            ReferenceSkeleton = new FReferenceSkeleton(info, pose),
+        });
+    }
+
+    private static string[] JointsOf(UsdPrim skelRoot) => skelRoot.Children
+        .SelectMany(c => c.Properties)
+        .OfType<UsdAttribute>()
+        .Single(a => a.Name == "joints")
+        .Value.AsValues()
+        .Select(v => (string) v.RawValue!)
+        .ToArray();
+
+    /// <summary>Every segment has to be legal, not just the string as a whole.</summary>
+    private static void AssertEveryPathIsLegal(IEnumerable<string> paths)
+    {
+        foreach (var path in paths)
+            foreach (var segment in path.Split('/'))
+                Assert.Matches(LegalIdentifier, segment);
+    }
+
+    private static string Serialize(SkeletonDto dto) =>
+        Encoding.UTF8.GetString(new UsdStage(dto.ToSkelRoot()).SerializeToBinary());
+
+    [Fact]
+    public void BipedBoneNamesBecomeLegalPathsInsteadOfPathsPixarRefusesToParse()
+    {
+        // The first four bones of a real Biped skeleton.
+        var joints = JointsOf(Skeleton(
+            ("Root", -1),
+            ("Bip001", 0),
+            ("Bip001-Pelvis", 1),
+            ("Bip001-Spine", 2)).ToSkelRoot());
+
+        AssertEveryPathIsLegal(joints);
+        Assert.Equal(
+        [
+            "Root",
+            "Root/Bip001",
+            "Root/Bip001/Bip001_Pelvis",
+            "Root/Bip001/Bip001_Pelvis/Bip001_Spine",
+        ], joints);
+    }
+
+    [Fact]
+    public void SiblingsThatSanitiseOntoEachOtherGetDistinctPaths()
+    {
+        // Taken from a shipped vehicle skeleton. Substituting without disambiguating turns
+        // "invalid" into "duplicated", which is rejected on identical grounds — the bug would
+        // survive the fix with its symptoms unchanged.
+        var joints = JointsOf(Skeleton(
+            ("root", -1),
+            ("steering-wheel", 0),
+            ("steering_wheel", 0)).ToSkelRoot());
+
+        AssertEveryPathIsLegal(joints);
+        Assert.Equal(joints.Length, joints.Distinct(StringComparer.Ordinal).Count());
+    }
+
+    [Fact]
+    public void TheBoneThatWasAlreadyLegalKeepsItsName()
+    {
+        // The cost of disambiguation belongs on the malformed name. First-come-first-served
+        // would push a perfectly good steering_wheel to steering_wheel_1 because a sibling was
+        // malformed, turning a 17-file fix into churn across thousands.
+        var joints = JointsOf(Skeleton(
+            ("root", -1),
+            ("steering-wheel", 0),
+            ("steering_wheel", 0)).ToSkelRoot());
+
+        Assert.Equal("root/steering_wheel", joints[2]);
+        Assert.NotEqual("root/steering_wheel", joints[1]);
+    }
+
+    [Fact]
+    public void SkeletonsThatWereAlreadyValidComeOutUnchanged()
+    {
+        // The overwhelming majority. Normalisation should leave no trace on them.
+        var joints = JointsOf(Skeleton(
+            ("Root", -1),
+            ("pelvis", 0),
+            ("spine_01", 1),
+            ("_leading_underscore", 1)).ToSkelRoot());
+
+        Assert.Equal(
+        [
+            "Root",
+            "Root/pelvis",
+            "Root/pelvis/spine_01",
+            "Root/pelvis/_leading_underscore",
+        ], joints);
+    }
+
+    [Fact]
+    public void NamesStartingWithADigitAreLegalisedToo()
+    {
+        // SdfPath rejects a segment beginning with a digit. UE is perfectly happy with one.
+        var joints = JointsOf(Skeleton(("Root", -1), ("01_jaw", 0)).ToSkelRoot());
+
+        AssertEveryPathIsLegal(joints);
+        Assert.Equal("Root/_01_jaw", joints[1]);
+    }
+
+    [Fact]
+    public void SameNameUnderDifferentParentsIsNotACollision()
+    {
+        // Common in mirrored rigs. Distinct paths do not conflict and must not be renamed.
+        var joints = JointsOf(Skeleton(
+            ("Root", -1),
+            ("L", 0),
+            ("R", 0),
+            ("hand", 1),
+            ("hand", 2)).ToSkelRoot());
+
+        Assert.Equal("Root/L/hand", joints[3]);
+        Assert.Equal("Root/R/hand", joints[4]);
+    }
+
+    [Fact]
+    public void TwoSiblingsWithTheSameLegalNameStillGetDistinctPaths()
+    {
+        // Both names are legal, so an implementation that only touches malformed names lets
+        // them through — but a duplicate path is rejected for exactly the reasons a malformed
+        // one is. Being legal is not on its own a reason to emit a duplicate.
+        var joints = JointsOf(Skeleton(
+            ("Root", -1),
+            ("hand", 0),
+            ("hand", 0)).ToSkelRoot());
+
+        AssertEveryPathIsLegal(joints);
+        Assert.Equal(joints.Length, joints.Distinct(StringComparer.Ordinal).Count());
+        Assert.Equal("Root/hand", joints[1]);
+    }
+
+    [Fact]
+    public void RenamedSkeletonsRecordWhatTheEngineActuallyCalledTheBones()
+    {
+        // Renaming is lossy: Bip001-L-Clavicle and Bip001_L_Clavicle collapse onto one
+        // identifier. Round-tripping back to UE needs the original spelling.
+        var usda = Serialize(Skeleton(("Root", -1), ("Bip001-Pelvis", 0)));
+
+        Assert.Contains("unrealJointNames", usda);
+        Assert.Contains("\"Bip001-Pelvis\"", usda);
+    }
+
+    [Fact]
+    public void UntouchedSkeletonsDoNotCarryTheOriginalNamesArray()
+    {
+        // On a skeleton nobody renamed it would only ever be a verbatim copy of the joints.
+        var usda = Serialize(Skeleton(("Root", -1), ("pelvis", 0)));
+
+        Assert.DoesNotContain("unrealJointNames", usda);
+    }
+
+    [Fact]
+    public void TheJointsArrayIsWrittenOnceAndReusedRatherThanRecomputed()
+    {
+        // UsdAnimFormat reads joints back off the Skeleton prim to hand to SkelAnimation.
+        // Pinning that path: were it ever to recompute them independently, any drift between
+        // the two normalisations would silently bind the animation to the wrong bones.
+        var root = Skeleton(("Root", -1), ("Bip001-Pelvis", 0), ("Bip001-Spine", 1)).ToSkelRoot();
+        var fromSkeleton = root.Children[0].Properties.OfType<UsdAttribute>().Single(a => a.Name == "joints");
+
+        Assert.Equal(JointsOf(root), fromSkeleton.Value.AsValues().Select(v => (string) v.RawValue!).ToArray());
+    }
+}

--- a/CUE4Parse/UE4/Assets/Exports/Animation/FReferenceSkeleton.cs
+++ b/CUE4Parse/UE4/Assets/Exports/Animation/FReferenceSkeleton.cs
@@ -12,6 +12,23 @@ public class FReferenceSkeleton
     public readonly FTransform[] FinalRefBonePose;
     public readonly Dictionary<string, int> FinalNameToIndexMap;
 
+    /// <summary>Builds a reference skeleton from bone data instead of reading one out of a package.</summary>
+    /// <remarks>
+    /// The archive constructor is otherwise the only way this type can come into existence, which
+    /// leaves anything that wants to exercise skeleton handling without a package — tests, tooling,
+    /// procedurally built rigs — with nothing to hand it.
+    /// </remarks>
+    public FReferenceSkeleton(FMeshBoneInfo[] boneInfo, FTransform[] bonePose)
+    {
+        FinalRefBoneInfo = boneInfo;
+        FinalRefBonePose = bonePose;
+        FinalNameToIndexMap = new Dictionary<string, int>(boneInfo.Length);
+        for (var i = 0; i < boneInfo.Length; i++)
+        {
+            FinalNameToIndexMap[boneInfo[i].Name.Text] = i;
+        }
+    }
+
     public FReferenceSkeleton(FAssetArchive Ar)
     {
         FinalRefBoneInfo = Ar.ReadArray(() => new FMeshBoneInfo(Ar));


### PR DESCRIPTION
### The symptom

Import a USD skeletal mesh exported from content authored in 3ds Max Biped, and Blender gives you the mesh, the materials and the textures — with an empty armature. Animations import with no Action. Nothing raises, the export reports success, and `usdchecker` says `Success!`.

The only signal is one line in the console, which the GUI does not surface:

```
Warning: import_skeleton: USD joint order array contains invalid or duplicated paths
Ill-formed SdfPath <Root/Bip001/Bip001-Pelvis>: parse error matching ... eolf
```

### The cause

`ToSkelRoot` interpolates `bone.Name` straight into the joint path:

```csharp
var path = bone.ParentIndex >= 0 ? $"{joints[bone.ParentIndex].RawValue}/{bone.Name}" : bone.Name;
```

USD identifiers only admit `[A-Za-z_][A-Za-z0-9_]*`. UE places no such restriction on bone names, and Biped rigs are full of `Bip001-L-Clavicle`. Consumers do not salvage what they can from an ill-formed path — Blender drops the whole skeleton.

`UsdPrim` already runs every prim name through `SanitizeIdentifier`. Joint paths are assembled from bone names rather than from prims, which is how they slipped past it — and why `def Skeleton "Boss_Gorilla_Skeleton"` is always spelled correctly while the array beneath it is not.

Confirmed by isolating the variable: on the exported files, substituting `-` for `_` **inside the joints arrays only**, changing nothing else, takes `Boss_Gorilla.usda` from 0 bones to 28 and `Gorilla_Idle.usda` from no Action to frames 0–121. Vertex, material and texture counts are identical either way.

### Why substitution alone is not the fix

It manufactures the other half of that same error message. A shipped vehicle skeleton carries **`steering-wheel` and `steering_wheel` as siblings**; folding both onto `steering_wheel` yields duplicate paths, which is rejected on identical grounds and presents identically.

So names are disambiguated within their sibling group — the scope USD requires uniqueness in — and names that are already legal are claimed **first**, before any substitution is handed out. Otherwise a well-formed `steering_wheel` gets pushed to `steering_wheel_1` because a sibling was malformed, turning a 17-file fix into churn across thousands. On that skeleton the result is:

| bone | exported as |
|---|---|
| `steering-wheel` | `steering_wheel_1` |
| `steering_wheel` | `steering_wheel` — untouched |

A legal name a sibling already claimed is left to the second pass too; two spellings both being legal is no reason to emit a duplicate path.

### Consistency across the three joint arrays

Nothing to keep in sync: `UsdAnimFormat` reads `joints` back off the Skeleton prim to hand to `SkelAnimation`, and mesh binding goes through `primvars:skel:jointIndices`. One array, written once. There is a test pinning that.

### Provenance

Renaming is lossy — `Bip001-L-Clavicle` and `Bip001_L_Clavicle` collapse onto one identifier — so skeletons that were actually renamed also carry the engine's spelling in a `custom uniform string[] unrealJointNames`. Skeletons that were not renamed do not; there it would only be a verbatim copy of `joints`.

### `FReferenceSkeleton`

Gains a constructor taking bone data. Reading one out of an `FAssetArchive` was previously the only way it could exist, which left tests, tooling and procedurally built rigs with no way to hand one over. It is what makes the tests in this PR possible.

### Measured

Two shipped titles, full re-export before and after:

| | UE 5.4 title | UE 4.25 title |
|---|---|---|
| skeleton-bearing `.usda` | 456 | 1,436 |
| affected before | **16** | **1** |
| files that changed on re-export | **exactly 16** | **exactly 1** |
| added / removed | 0 / 0 | 0 / 0 |
| everything else | 11,177 byte-identical | 22,309 byte-identical |
| illegal / duplicate paths after | 0 / 0 | 0 / 0 |

Headless Blender 5.2 on the affected assets: 0 bones → 28, 32, 32, 9 and 1 respectively; animations 0 Actions → frames 0–121, 0–77, 0–1459. Control assets (an 8-material building, a 55-bone character, an 86-bone character with animation, a 1,802-mesh level) are byte-identical to before and import unchanged. `usdchecker` passes on the renamed skeletons.

The only invalid character encountered across both titles was the hyphen; the fix is not written around that assumption.

### Tests

Ten cases in `CUE4Parse.Tests/UsdJointPathTests.cs`, using skeletons taken from shipped content rather than invented. Falsified: restoring the `bone.Name` interpolation turns three of them red. `CUE4Parse.Tests` picks up a reference to `CUE4Parse-Conversion`, which it did not have before.

Branch is cut from current `master` (`f081f32e`); `dotnet test` green, 18/18.
