### PR TITLE
Fix UE5.8 PCG metadata attributes

### DIFF
--- a/CUE4Parse.Tests/Fixtures/UE5_8/Tests/FixtureAdvancedAssetTests.cs
+++ b/CUE4Parse.Tests/Fixtures/UE5_8/Tests/FixtureAdvancedAssetTests.cs
@@ -8,6 +8,7 @@ using CUE4Parse.UE4.Assets.Exports.Engine;
 using CUE4Parse.UE4.Assets.Exports.NNE;
 using CUE4Parse.UE4.Assets.Exports.PCG;
 using CUE4Parse.UE4.Objects.ControlRig;
+using CUE4Parse.UE4.Objects.Core.Math;
 using CUE4Parse.UE4.Objects.Engine.VectorField;
 using CUE4Parse.UE4.Objects.PCG;
 using CUE4Parse.UE4.Objects.UObject;
@@ -97,13 +98,42 @@ public class FixtureAdvancedAssetTests
     [Theory]
     [InlineData(FixtureSerialization.Tagged)]
     [InlineData(FixtureSerialization.Unversioned)]
-    public void PcgParamDataDeserializesMetadataDomainHeader(FixtureSerialization serialization)
+    public void PcgParamDataDeserializesTypedMetadata(FixtureSerialization serialization)
     {
         using var provider = CreateMountedIoStoreProvider(serialization);
         var exports = LoadPackageExports(provider,
             "CUE4ParseFixtures/Content/Fixtures/PCG/PCG_Parameters.uasset");
+        var paramData = Assert.Single(exports, export => export.Name == "PCG_Parameters");
         var metadata = Assert.Single(exports.OfType<UPCGMetadata>());
         Assert.Equal(EPCGMetadataDomainFlag.Elements, metadata.ArchiveDefaultDomain?.Flag);
+        var domain = Assert.Single(metadata.MetadataDomains,
+            pair => pair.Key.Flag == EPCGMetadataDomainFlag.Elements).Value;
+        Assert.Equal([-1L, -1L], domain.ParentKeys);
+        Assert.Equal(3, domain.Attributes.Count);
+        Assert.All(domain.Attributes.Values, attribute => Assert.Empty(attribute.Descriptor.ContainerTypes));
+
+        var nameMap = paramData.Get<Dictionary<FName, long>>("NameMap");
+        Assert.Equal(2, nameMap.Count);
+        var firstKey = Assert.Single(nameMap, pair => pair.Key.Text == "FixtureFirst").Value;
+        var secondKey = Assert.Single(nameMap, pair => pair.Key.Text == "FixtureSecond").Value;
+
+        var count = Assert.IsType<FPCGMetadataAttribute<int>>(domain.Attributes[new FName("FixtureCount")]);
+        Assert.Equal(EPCGMetadataTypes.Integer32, count.Descriptor.ValueType);
+        Assert.Equal(-1, count.DefaultValue);
+        Assert.Equal(101, GetPcgValue(count, firstKey));
+        Assert.Equal(202, GetPcgValue(count, secondKey));
+
+        var label = Assert.IsType<FPCGMetadataAttribute<string>>(domain.Attributes[new FName("FixtureLabel")]);
+        Assert.Equal(EPCGMetadataTypes.String, label.Descriptor.ValueType);
+        Assert.Equal("DefaultLabel", label.DefaultValue);
+        Assert.Equal("First parameter row", GetPcgValue(label, firstKey));
+        Assert.Equal("Second parameter row", GetPcgValue(label, secondKey));
+
+        var vector = Assert.IsType<FPCGMetadataAttribute<FVector>>(domain.Attributes[new FName("FixtureVector")]);
+        Assert.Equal(EPCGMetadataTypes.Vector, vector.Descriptor.ValueType);
+        AssertVector(vector.DefaultValue, 0.0f, 0.0f, 0.0f);
+        AssertVector(GetPcgValue(vector, firstKey), 1.25f, -2.5f, 3.75f);
+        AssertVector(GetPcgValue(vector, secondKey), -4.5f, 5.25f, -6.75f);
     }
 
     [Theory]
@@ -164,5 +194,12 @@ public class FixtureAdvancedAssetTests
             (float) BinaryPrimitives.ReadHalfLittleEndian(color[2..]),
             (float) BinaryPrimitives.ReadHalfLittleEndian(color[4..]),
             (float) BinaryPrimitives.ReadHalfLittleEndian(color[6..]));
+    }
+
+    private static T GetPcgValue<T>(FPCGMetadataAttribute<T> attribute, long entryKey)
+    {
+        var valueKey = attribute.EntryToValueKeyMap[entryKey];
+        Assert.InRange(valueKey, 0, attribute.Values.Length - 1);
+        return attribute.Values[valueKey];
     }
 }

--- a/CUE4Parse/UE4/Objects/PCG/FPCGMetadataAttribute.cs
+++ b/CUE4Parse/UE4/Objects/PCG/FPCGMetadataAttribute.cs
@@ -1,7 +1,11 @@
+using CUE4Parse.UE4.Assets.Objects;
+using CUE4Parse.UE4.Assets.Objects.Properties;
 using CUE4Parse.UE4.Assets.Readers;
 using CUE4Parse.UE4.Exceptions;
+using CUE4Parse.UE4.Objects.Core.i18N;
 using CUE4Parse.UE4.Objects.Core.Math;
 using CUE4Parse.UE4.Objects.UObject;
+using CUE4Parse.UE4.Versions;
 using Newtonsoft.Json;
 
 namespace CUE4Parse.UE4.Objects.PCG;
@@ -24,10 +28,167 @@ public enum EPCGMetadataTypes : byte
     SoftObjectPath,
     SoftClassPath,
 
-    Count,
+    EndLegacyTypes,
+    Byte,
+    Text,
+    Enum,
+    Struct,
+    Object,
+    SoftObject,
+    Class,
+    SoftClass,
 
+    Count,
     Unknown = 255,
-};
+}
+
+public enum EPCGMetadataAttributeContainerTypes
+{
+    None,
+    Array,
+    Set,
+    Map
+}
+
+public class FPCGMetadataAttributeDesc
+{
+    public FName Name;
+    public EPCGMetadataTypes ValueType = EPCGMetadataTypes.Unknown;
+    public EPCGMetadataAttributeContainerTypes[] ContainerTypes = [];
+    public FPackageIndex? ValueTypeObject;
+    public EPCGMetadataTypes KeyType = EPCGMetadataTypes.Unknown;
+    public FPackageIndex? KeyTypeObject;
+
+    public FPCGMetadataAttributeDesc(EPCGMetadataTypes valueType, FName name)
+    {
+        Name = name;
+        ValueType = valueType;
+    }
+
+    public FPCGMetadataAttributeDesc(FAssetArchive Ar, FName fallbackName)
+    {
+        var fallback = new FStructFallback(Ar, "PCGMetadataAttributeDesc");
+        Name = fallback.GetOrDefault(nameof(Name), fallbackName);
+        ValueType = fallback.GetOrDefault(nameof(ValueType), EPCGMetadataTypes.Unknown);
+        ContainerTypes = fallback.GetOrDefault<EPCGMetadataAttributeContainerTypes[]>(nameof(ContainerTypes), []);
+        ValueTypeObject = fallback.GetOrDefault<FPackageIndex?>(nameof(ValueTypeObject));
+        KeyType = fallback.GetOrDefault(nameof(KeyType), EPCGMetadataTypes.Unknown);
+        KeyTypeObject = fallback.GetOrDefault<FPackageIndex?>(nameof(KeyTypeObject));
+    }
+
+    internal FPropertyTagType ReadValue(FAssetArchive Ar)
+    {
+        var (propertyType, tagData) = CreatePropertyTagData();
+        return FPropertyTagType.ReadPropertyTagType(Ar, propertyType, tagData, ReadType.RAW)
+               ?? throw new ParserException(Ar, $"Unable to read PCG metadata value of type {ValueType}");
+    }
+
+    private (string Type, FPropertyTagData Data) CreatePropertyTagData()
+    {
+        var value = CreateScalarPropertyTagData(ValueType, ValueTypeObject);
+        for (var i = ContainerTypes.Length - 1; i >= 0; i--)
+        {
+            value = ContainerTypes[i] switch
+            {
+                EPCGMetadataAttributeContainerTypes.None => value,
+                EPCGMetadataAttributeContainerTypes.Array => ("ArrayProperty", new FPropertyTagData
+                {
+                    Type = "ArrayProperty", InnerType = value.Type, InnerTypeData = value.Data
+                }),
+                EPCGMetadataAttributeContainerTypes.Set => ("SetProperty", new FPropertyTagData
+                {
+                    Type = "SetProperty", InnerType = value.Type, InnerTypeData = value.Data
+                }),
+                EPCGMetadataAttributeContainerTypes.Map => CreateMapPropertyTagData(value),
+                _ => throw new ParserException($"Unknown PCG metadata container type {ContainerTypes[i]}")
+            };
+        }
+
+        return value;
+    }
+
+    private (string Type, FPropertyTagData Data) CreateMapPropertyTagData((string Type, FPropertyTagData Data) value)
+    {
+        var key = CreateScalarPropertyTagData(KeyType, KeyTypeObject);
+        return ("MapProperty", new FPropertyTagData
+        {
+            Type = "MapProperty",
+            InnerType = key.Type,
+            InnerTypeData = key.Data,
+            ValueType = value.Type,
+            ValueTypeData = value.Data
+        });
+    }
+
+    private static (string Type, FPropertyTagData Data) CreateScalarPropertyTagData(
+        EPCGMetadataTypes valueType, FPackageIndex? typeObject)
+    {
+        var propertyType = valueType switch
+        {
+            EPCGMetadataTypes.Float => "FloatProperty",
+            EPCGMetadataTypes.Double => "DoubleProperty",
+            EPCGMetadataTypes.Integer32 => "IntProperty",
+            EPCGMetadataTypes.Integer64 => "Int64Property",
+            EPCGMetadataTypes.Vector2 or EPCGMetadataTypes.Vector or EPCGMetadataTypes.Vector4 or
+                EPCGMetadataTypes.Quaternion or EPCGMetadataTypes.Transform or EPCGMetadataTypes.Rotator or
+                EPCGMetadataTypes.SoftObjectPath or EPCGMetadataTypes.SoftClassPath or EPCGMetadataTypes.Struct => "StructProperty",
+            EPCGMetadataTypes.String => "StrProperty",
+            EPCGMetadataTypes.Boolean => "BoolProperty",
+            EPCGMetadataTypes.Name => "NameProperty",
+            EPCGMetadataTypes.Byte => "ByteProperty",
+            EPCGMetadataTypes.Text => "TextProperty",
+            EPCGMetadataTypes.Enum => "EnumProperty",
+            EPCGMetadataTypes.Object or EPCGMetadataTypes.Class => "ObjectProperty",
+            EPCGMetadataTypes.SoftObject or EPCGMetadataTypes.SoftClass => "SoftObjectProperty",
+            _ => throw new ParserException($"Unsupported PCG metadata value type {valueType}")
+        };
+
+        var data = new FPropertyTagData { Type = propertyType };
+        if (propertyType == "StructProperty")
+        {
+            data.StructType = valueType switch
+            {
+                EPCGMetadataTypes.Vector2 => "Vector2D",
+                EPCGMetadataTypes.Vector => "Vector",
+                EPCGMetadataTypes.Vector4 => "Vector4",
+                EPCGMetadataTypes.Quaternion => "Quat",
+                EPCGMetadataTypes.Transform => "Transform",
+                EPCGMetadataTypes.Rotator => "Rotator",
+                EPCGMetadataTypes.SoftObjectPath => "SoftObjectPath",
+                EPCGMetadataTypes.SoftClassPath => "SoftClassPath",
+                _ => typeObject?.Name
+            };
+        }
+        else if (propertyType == "EnumProperty")
+        {
+            data.EnumName = typeObject?.Name;
+            data.InnerType = "ByteProperty";
+            data.InnerTypeData = new FPropertyTagData { Type = "ByteProperty" };
+        }
+
+        return (propertyType, data);
+    }
+}
+
+internal sealed class FPCGMetadataAttributeHeader
+{
+    public readonly Dictionary<long, int> EntryToValueKeyMap;
+    public readonly int ParentAttributeId;
+    public readonly FName Name;
+    public readonly int AttributeId;
+    public readonly FPCGMetadataAttributeDesc Descriptor;
+
+    public FPCGMetadataAttributeHeader(FAssetArchive Ar, FPCGMetadataAttributeDesc descriptor, bool usesGenericValueLayout)
+    {
+        EntryToValueKeyMap = Ar.ReadMap(Ar.Read<long>, Ar.Read<int>);
+        ParentAttributeId = Ar.Read<int>();
+        Name = Ar.ReadFName();
+        AttributeId = Ar.Read<int>();
+        Descriptor = usesGenericValueLayout && ParentAttributeId < 0
+            ? new FPCGMetadataAttributeDesc(Ar, Name)
+            : descriptor;
+    }
+}
 
 public abstract class FPCGMetadataAttributeBase
 {
@@ -36,6 +197,7 @@ public abstract class FPCGMetadataAttributeBase
     public int ParentAttributeId;
     public FName Name;
     public int AttributeId;
+    public FPCGMetadataAttributeDesc Descriptor;
 
     public FPCGMetadataAttributeBase(FAssetArchive Ar)
     {
@@ -43,32 +205,68 @@ public abstract class FPCGMetadataAttributeBase
         ParentAttributeId = Ar.Read<int>();
         Name = Ar.ReadFName();
         AttributeId = Ar.Read<int>();
+        Descriptor = new FPCGMetadataAttributeDesc(EPCGMetadataTypes.Unknown, Name);
     }
 
-    public static FPCGMetadataAttributeBase ReadPCGMetadataAttribute(FAssetArchive Ar)
+    private protected FPCGMetadataAttributeBase(FPCGMetadataAttributeHeader header)
     {
-        var attributeTypeId = Ar.Read<int>();
-        FPCGMetadataAttributeBase attribute = attributeTypeId switch
-        {
-            0 => new FPCGMetadataAttribute<float>(Ar, Ar.Read<float>),
-            1 => new FPCGMetadataAttribute<double>(Ar, Ar.Read<double>),
-            2 => new FPCGMetadataAttribute<int>(Ar, Ar.Read<int>),
-            3 => new FPCGMetadataAttribute<long>(Ar, Ar.Read<long>),
-            4 => new FPCGMetadataAttribute<FVector2D>(Ar, () => new FVector2D(Ar)),
-            5 => new FPCGMetadataAttribute<FVector>(Ar, () => new FVector(Ar)),
-            6 => new FPCGMetadataAttribute<FVector4>(Ar, () => new FVector4(Ar)),
-            7 => new FPCGMetadataAttribute<FQuat>(Ar, () => new FQuat(Ar)),
-            8 => new FPCGMetadataAttribute<FTransform>(Ar, () => new FTransform(Ar)),
-            9 => new FPCGMetadataAttribute<string>(Ar, Ar.ReadFString),
-            10 => new FPCGMetadataAttribute<bool>(Ar, Ar.ReadFlag),
-            11 => new FPCGMetadataAttribute<FRotator>(Ar, () => new FRotator(Ar)),
-            12 => new FPCGMetadataAttribute<FName>(Ar, Ar.ReadFName),
-            13 or 14 => new FPCGMetadataAttribute<FSoftObjectPath>(Ar, () => new FSoftObjectPath(Ar)),
-            _ => throw new ParserException($"Unknown EPCGMetadataTypes value {attributeTypeId}")
-        };
-        if (attributeTypeId == 10)
+        EntryToValueKeyMap = header.EntryToValueKeyMap;
+        ParentAttributeId = header.ParentAttributeId;
+        Name = header.Name;
+        AttributeId = header.AttributeId;
+        Descriptor = header.Descriptor;
+    }
+
+    public static FPCGMetadataAttributeBase ReadPCGMetadataAttribute(FAssetArchive Ar) =>
+        ReadPCGMetadataAttribute(Ar, default);
+
+    public static FPCGMetadataAttributeBase ReadPCGMetadataAttribute(FAssetArchive Ar, FName attributeName)
+    {
+        var version = FFortniteMainBranchObjectVersion.Get(Ar);
+        var usesDescriptorLayout = version >=
+                                   FFortniteMainBranchObjectVersion.Type.MergePCGMetadataAttributeBaseAndGeneric;
+        var usesGenericValueLayout = version >=
+                                     FFortniteMainBranchObjectVersion.Type.ConvertFPCGMetadataAttributeToGenericAttributes;
+        var descriptor = usesDescriptorLayout
+            ? new FPCGMetadataAttributeDesc(Ar, attributeName)
+            : new FPCGMetadataAttributeDesc((EPCGMetadataTypes) Ar.Read<int>(), attributeName);
+        var header = new FPCGMetadataAttributeHeader(Ar, descriptor, usesGenericValueLayout);
+
+        FPCGMetadataAttributeBase attribute = header.Descriptor.ContainerTypes.Length == 0
+            ? ReadScalarAttribute(Ar, header, usesGenericValueLayout)
+            : new FPCGMetadataGenericAttribute(Ar, header);
+
+        if (!usesGenericValueLayout && descriptor.ValueType == EPCGMetadataTypes.Boolean)
             Ar.Position += 3;
         return attribute;
+    }
+
+    private static FPCGMetadataAttributeBase ReadScalarAttribute(
+        FAssetArchive Ar, FPCGMetadataAttributeHeader header, bool usesGenericLayout)
+    {
+        return header.Descriptor.ValueType switch
+        {
+            EPCGMetadataTypes.Float => new FPCGMetadataAttribute<float>(Ar, header, Ar.Read<float>, usesGenericLayout),
+            EPCGMetadataTypes.Double => new FPCGMetadataAttribute<double>(Ar, header, Ar.Read<double>, usesGenericLayout),
+            EPCGMetadataTypes.Integer32 => new FPCGMetadataAttribute<int>(Ar, header, Ar.Read<int>, usesGenericLayout),
+            EPCGMetadataTypes.Integer64 => new FPCGMetadataAttribute<long>(Ar, header, Ar.Read<long>, usesGenericLayout),
+            EPCGMetadataTypes.Vector2 => new FPCGMetadataAttribute<FVector2D>(Ar, header, () => new FVector2D(Ar), usesGenericLayout),
+            EPCGMetadataTypes.Vector => new FPCGMetadataAttribute<FVector>(Ar, header, () => new FVector(Ar), usesGenericLayout),
+            EPCGMetadataTypes.Vector4 => new FPCGMetadataAttribute<FVector4>(Ar, header, () => new FVector4(Ar), usesGenericLayout),
+            EPCGMetadataTypes.Quaternion => new FPCGMetadataAttribute<FQuat>(Ar, header, () => new FQuat(Ar), usesGenericLayout),
+            EPCGMetadataTypes.Transform => new FPCGMetadataAttribute<FTransform>(Ar, header, () => new FTransform(Ar), usesGenericLayout),
+            EPCGMetadataTypes.String => new FPCGMetadataAttribute<string>(Ar, header, Ar.ReadFString, usesGenericLayout),
+            EPCGMetadataTypes.Boolean => new FPCGMetadataAttribute<bool>(Ar, header, Ar.ReadFlag, usesGenericLayout),
+            EPCGMetadataTypes.Rotator => new FPCGMetadataAttribute<FRotator>(Ar, header, () => new FRotator(Ar), usesGenericLayout),
+            EPCGMetadataTypes.Name => new FPCGMetadataAttribute<FName>(Ar, header, Ar.ReadFName, usesGenericLayout),
+            EPCGMetadataTypes.SoftObjectPath or EPCGMetadataTypes.SoftClassPath =>
+                new FPCGMetadataAttribute<FSoftObjectPath>(Ar, header, () => new FSoftObjectPath(Ar), usesGenericLayout),
+            EPCGMetadataTypes.Byte or EPCGMetadataTypes.Enum =>
+                new FPCGMetadataAttribute<byte>(Ar, header, Ar.Read<byte>, usesGenericLayout),
+            EPCGMetadataTypes.Text => new FPCGMetadataAttribute<FText>(Ar, header, () => new FText(Ar), usesGenericLayout),
+            _ when usesGenericLayout => new FPCGMetadataGenericAttribute(Ar, header),
+            _ => throw new ParserException(Ar, $"Unknown EPCGMetadataTypes value {header.Descriptor.ValueType}")
+        };
     }
 }
 
@@ -76,11 +274,39 @@ public class FPCGMetadataAttribute<T> : FPCGMetadataAttributeBase
 {
     [JsonIgnore]
     public T[] Values = [];
-    public T DefaultValue = default;
+    public T DefaultValue = default!;
 
     public FPCGMetadataAttribute(FAssetArchive Ar, Func<T> getter) : base(Ar)
     {
         Values = Ar.ReadArray(getter);
         DefaultValue = getter();
+    }
+
+    internal FPCGMetadataAttribute(FAssetArchive Ar, FPCGMetadataAttributeHeader header, Func<T> getter,
+        bool usesGenericLayout) : base(header)
+    {
+        if (usesGenericLayout)
+        {
+            DefaultValue = getter();
+            Values = Ar.ReadArray(getter);
+        }
+        else
+        {
+            Values = Ar.ReadArray(getter);
+            DefaultValue = getter();
+        }
+    }
+}
+
+public class FPCGMetadataGenericAttribute : FPCGMetadataAttributeBase
+{
+    public FPropertyTagType DefaultValue;
+    [JsonIgnore]
+    public FPropertyTagType[] Values;
+
+    internal FPCGMetadataGenericAttribute(FAssetArchive Ar, FPCGMetadataAttributeHeader header) : base(header)
+    {
+        DefaultValue = Descriptor.ReadValue(Ar);
+        Values = Ar.ReadArray(() => Descriptor.ReadValue(Ar));
     }
 }

--- a/CUE4Parse/UE4/Objects/PCG/FPCGMetadataDomain.cs
+++ b/CUE4Parse/UE4/Objects/PCG/FPCGMetadataDomain.cs
@@ -10,7 +10,14 @@ public class FPCGMetadataDomain
 
     public FPCGMetadataDomain(FAssetArchive Ar)
     {
-        Attributes = Ar.ReadMap(Ar.ReadFName, () => FPCGMetadataAttributeBase.ReadPCGMetadataAttribute(Ar));
+        var attributeCount = Ar.Read<int>();
+        Attributes = new Dictionary<FName, FPCGMetadataAttributeBase>(attributeCount);
+        for (var i = 0; i < attributeCount; i++)
+        {
+            var attributeName = Ar.ReadFName();
+            Attributes.Add(attributeName, FPCGMetadataAttributeBase.ReadPCGMetadataAttribute(Ar, attributeName));
+        }
+
         ParentKeys = Ar.ReadArray<long>();
     }
 }


### PR DESCRIPTION
## Summary
- Read the versioned PCG metadata attribute descriptor layout.
- Deserialize generic defaults and values while preserving legacy formats.
- Cover deterministic typed metadata in tagged and unversioned packages.

Fixes #408