### PR TITLE
fix generic virtual methods for NativeAOT

### DIFF
--- a/CUE4Parse/GameTypes/2XKO/Assets/Exports/ULionAnimSequenceAssetUserData.cs
+++ b/CUE4Parse/GameTypes/2XKO/Assets/Exports/ULionAnimSequenceAssetUserData.cs
@@ -18,9 +18,9 @@ public class ULionAnimSequenceAssetUserData : UAssetUserData
     {
         base.Deserialize(Ar, validPos);
         Data = Ar.ReadMap(Ar.ReadFName,
-            () => Ar.ReadMap(Ar.Read<Fixed64>,
+            () => Ar.ReadMap(() => Ar.Read<Fixed64>(),
                 () => new FTransform(Ar.Read<FixedQuaternion>(), Ar.Read<Vector3d>(), Ar.Read<Vector3d>())));
-        Vectors = Ar.ReadMap(Ar.Read<Fixed64>, () => (FVector)Ar.Read<Vector3d>());
+        Vectors = Ar.ReadMap(() => Ar.Read<Fixed64>(), () => (FVector)Ar.Read<Vector3d>());
     }
 
     protected internal override void WriteJson(JsonWriter writer, JsonSerializer serializer)

--- a/CUE4Parse/GameTypes/CrystalOfAtlan/Pak/CoAPakFileReader.cs
+++ b/CUE4Parse/GameTypes/CrystalOfAtlan/Pak/CoAPakFileReader.cs
@@ -196,7 +196,7 @@ public partial class PakFileReader
         if (total < fileCount)
         {
             var regex = new Regex(@"^(0|[1-9]\d*)$");
-            var pathHashIndex = directoryIndex.ReadMap(directoryIndex.Read<ulong>, directoryIndex.Read<int>);
+            var pathHashIndex = directoryIndex.ReadMap(() => directoryIndex.Read<ulong>(), () => directoryIndex.Read<int>());
             var used = new HashSet<ulong>();
 
             void FindPayload(GenericBufferReader Ar, string path, string extension, bool warning = false)

--- a/CUE4Parse/GameTypes/FF7/Assets/Exports/UEndStreamableAssetPump.cs
+++ b/CUE4Parse/GameTypes/FF7/Assets/Exports/UEndStreamableAssetPump.cs
@@ -12,7 +12,7 @@ public struct FF7AssetPumpStruct1
 
 public struct FF7AssetPumpStruct2(FMemoryMappedImageArchive Ar)
 {
-    public byte[][] idk = Ar.ReadArray(Ar.ReadArray<byte>, 1);
+    public byte[][] idk = Ar.ReadArray(() => Ar.ReadArray<byte>(), 1);
     public int Type = Ar.Read<int>();
 }
 

--- a/CUE4Parse/GameTypes/HonorOfKings/Vfs/HoKdbContainerStream.cs
+++ b/CUE4Parse/GameTypes/HonorOfKings/Vfs/HoKdbContainerStream.cs
@@ -167,7 +167,7 @@ public sealed class HoKdbContainerStream : FRandomAccessFileStreamArchive
         using var Ar = new FByteArchive(indexPath, File.ReadAllBytes(indexPath));
         if (Ar.Read<ulong>() == _hash)
         {
-            CompressedChunks = Ar.ReadMap(Ar.Read<ulong>, Ar.ReadArray<FHoKCompressedChunk>);
+            CompressedChunks = Ar.ReadMap(() => Ar.Read<ulong>(), () => Ar.ReadArray<FHoKCompressedChunk>());
         }
         else
         {

--- a/CUE4Parse/GameTypes/OtherGames/Objects/Nightingale.cs
+++ b/CUE4Parse/GameTypes/OtherGames/Objects/Nightingale.cs
@@ -54,8 +54,8 @@ public class AffinityTable : UObject
             }
         }
 
-        Rows = Ar.ReadMap(Ar.ReadFName, Ar.Read<FVector4>);
-        Columns = Ar.ReadMap(Ar.ReadFName, Ar.Read<FVector4>);
+        Rows = Ar.ReadMap(Ar.ReadFName, () => Ar.Read<FVector4>());
+        Columns = Ar.ReadMap(Ar.ReadFName, () => Ar.Read<FVector4>());
 
         Tags = Ar.ReadMap(Ar.ReadFName, () => Ar.ReadMap(Ar.ReadFString, () => (Ar.ReadFName(), Ar.ReadFName())));
     }

--- a/CUE4Parse/GameTypes/OtherGames/Objects/Strinova.cs
+++ b/CUE4Parse/GameTypes/OtherGames/Objects/Strinova.cs
@@ -10,6 +10,6 @@ public abstract class TEveryPlatformProperty<T>(FAssetArchive Ar, Func<T> getter
     public Dictionary<FName, T> PlatformOverrides = Ar.ReadMap(Ar.ReadFName, getter);
 }
 
-public class FEveryPlatformFloat(FAssetArchive Ar) : TEveryPlatformProperty<float>(Ar, Ar.Read<float>);
+public class FEveryPlatformFloat(FAssetArchive Ar) : TEveryPlatformProperty<float>(Ar, () => Ar.Read<float>());
 public class FEveryPlatformBool(FAssetArchive Ar) : TEveryPlatformProperty<bool>(Ar, Ar.ReadBoolean);
-public class FEveryPlatformInt(FAssetArchive Ar) : TEveryPlatformProperty<int>(Ar, Ar.Read<int>);
+public class FEveryPlatformInt(FAssetArchive Ar) : TEveryPlatformProperty<int>(Ar, () => Ar.Read<int>());

--- a/CUE4Parse/GameTypes/OtherGames/Objects/Subnautica2.cs
+++ b/CUE4Parse/GameTypes/OtherGames/Objects/Subnautica2.cs
@@ -16,7 +16,7 @@ public struct FUWEWorldPopSpatialCell
 
 public class FUWEWorldPopSpatialLayer(FAssetArchive Ar) : IUStruct
 {
-    public Dictionary<long, FUWEWorldPopSpatialCell> CellMap = Ar.ReadMap(Ar.Read<long>, Ar.Read<FUWEWorldPopSpatialCell>);
+    public Dictionary<long, FUWEWorldPopSpatialCell> CellMap = Ar.ReadMap(() => Ar.Read<long>(), () => Ar.Read<FUWEWorldPopSpatialCell>());
 }
 
 public class AMercunaNavDataChunk : AActor

--- a/CUE4Parse/GameTypes/PUBG/Assets/Objects/TslObjects.cs
+++ b/CUE4Parse/GameTypes/PUBG/Assets/Objects/TslObjects.cs
@@ -11,7 +11,7 @@ public class FTslSomeSKStruct : IUStruct
     public FTslSomeSKStruct(FAssetArchive Ar)
     {
         SomeBoneStructs = Ar.ReadArray(() =>
-            Ar.ReadArray(() => Ar.ReadMap(Ar.Read<FTslSomeBoneStruct>, Ar.Read<FTslSomeBoneStruct>)));
+            Ar.ReadArray(() => Ar.ReadMap(() => Ar.Read<FTslSomeBoneStruct>(), () => Ar.Read<FTslSomeBoneStruct>())));
     }
 }
 

--- a/CUE4Parse/GameTypes/RocoKingdomWorld/Assets/Objects/FRocoAudioConfig.cs
+++ b/CUE4Parse/GameTypes/RocoKingdomWorld/Assets/Objects/FRocoAudioConfig.cs
@@ -56,12 +56,12 @@ public class FRocoAudioConfig
 
     public FRocoAudioConfig(FArchive Ar, FArchive descAr, FArchive typeDescAr)
     {
-        var typeDescTable = typeDescAr.ReadMap(typeDescAr.Read<byte>, () => typeDescAr.Read<byte>() != 0);
-        var descTable = descAr.ReadMap(descAr.Read<int>, descAr.ReadFString);
+        var typeDescTable = typeDescAr.ReadMap(() => typeDescAr.Read<byte>(), () => typeDescAr.Read<byte>() != 0);
+        var descTable = descAr.ReadMap(() => descAr.Read<int>(), descAr.ReadFString);
 
         Entries = Ar.ReadArray(() => new FAudioEntry(Ar, descTable, typeDescTable));
         EventEntries = Ar.ReadArray(() => new FAudioEventEntry(Ar));
-        SurfaceTypes = Ar.ReadMap(Ar.Read<uint>, Ar.ReadFString);
-        MaterialTypes = Ar.ReadMap(Ar.Read<uint>, Ar.ReadFString);
+        SurfaceTypes = Ar.ReadMap(() => Ar.Read<uint>(), Ar.ReadFString);
+        MaterialTypes = Ar.ReadMap(() => Ar.Read<uint>(), Ar.ReadFString);
     }
 }

--- a/CUE4Parse/UE4/AssetRegistry/Objects/FStore.cs
+++ b/CUE4Parse/UE4/AssetRegistry/Objects/FStore.cs
@@ -42,7 +42,7 @@ namespace CUE4Parse.UE4.AssetRegistry.Objects
             }
 
             if (order == ELoadOrder.TextFirst) Ar.AlignPosInArchive();
-            NumberlessNames = Ar.ReadArray(nums[0], Ar.Read<uint>);
+            NumberlessNames = Ar.ReadArray(nums[0], () => Ar.Read<uint>());
 
             if (order == ELoadOrder.TextFirst) Ar.AlignPosInArchive();
             Names = Ar.ReadArray(nums[1], Ar.ReadFName);
@@ -59,10 +59,10 @@ namespace CUE4Parse.UE4.AssetRegistry.Objects
             }
 
             if (order == ELoadOrder.TextFirst) Ar.AlignPosInArchive();
-            AnsiStringOffsets = Ar.ReadArray(nums[5], Ar.Read<uint>);
+            AnsiStringOffsets = Ar.ReadArray(nums[5], () => Ar.Read<uint>());
 
             if (order == ELoadOrder.TextFirst) Ar.AlignPosInArchive();
-            WideStringOffsets = Ar.ReadArray(nums[6], Ar.Read<uint>);
+            WideStringOffsets = Ar.ReadArray(nums[6], () => Ar.Read<uint>());
 
             if (order == ELoadOrder.TextFirst) Ar.AlignPosInArchive();
             AnsiStrings = Ar.ReadBytes(nums[7]);

--- a/CUE4Parse/UE4/Assets/Exports/Actor/AActor.cs
+++ b/CUE4Parse/UE4/Assets/Exports/Actor/AActor.cs
@@ -276,7 +276,7 @@ public class APrefabInstance : AActor
         base.Deserialize(Ar, validPos);
 
         Ar.ReadMap(() => new FPackageIndex(Ar), () => new FPackageIndex(Ar)); // ArchetypeToInstanceMap
-        Ar.ReadMap(() => new FPackageIndex(Ar), Ar.Read<int>); // PI_ObjectMap
+        Ar.ReadMap(() => new FPackageIndex(Ar), () => Ar.Read<int>()); // PI_ObjectMap
     }
 }
 

--- a/CUE4Parse/UE4/Assets/Exports/Animation/FReferenceSkeleton.cs
+++ b/CUE4Parse/UE4/Assets/Exports/Animation/FReferenceSkeleton.cs
@@ -28,7 +28,7 @@ public class FReferenceSkeleton
             FinalRefBonePose = Ar.ReadArray(() => new FTransform(Ar));
         }
 
-        FinalNameToIndexMap = Ar.Ver >= EUnrealEngineObjectUE4Version.REFERENCE_SKELETON_REFACTOR ? Ar.ReadMap(() => Ar.ReadFName().Text, Ar.Read<int>) : [];
+        FinalNameToIndexMap = Ar.Ver >= EUnrealEngineObjectUE4Version.REFERENCE_SKELETON_REFACTOR ? Ar.ReadMap(() => Ar.ReadFName().Text, () => Ar.Read<int>()) : [];
 
         if (Ar.Game == GAME_DaysGone) Ar.SkipFixedArray(12);
 

--- a/CUE4Parse/UE4/Assets/Exports/Animation/FSmartNameMapping.cs
+++ b/CUE4Parse/UE4/Assets/Exports/Animation/FSmartNameMapping.cs
@@ -22,13 +22,13 @@ public class FSmartNameMapping
         {
             if (frwAniVer < FAnimPhysObjectVersion.Type.SmartNameRefactorForDeterministicCooking)
             {
-                GuidMap = Ar.ReadMap(Ar.ReadFName, Ar.Read<FGuid>);
+                GuidMap = Ar.ReadMap(Ar.ReadFName, () => Ar.Read<FGuid>());
             }
         }
         else if (Ar.Ver >= EUnrealEngineObjectUE4Version.SKELETON_ADD_SMARTNAMES)
         {
             Ar.Read<ushort>();
-            UidMap = Ar.ReadMap(Ar.Read<ushort>, Ar.ReadFName);
+            UidMap = Ar.ReadMap(() => Ar.Read<ushort>(), Ar.ReadFName);
         }
 
         if (frwObjVer >= FFrameworkObjectVersion.Type.MoveCurveTypesToSkeleton)

--- a/CUE4Parse/UE4/Assets/Exports/Animation/PoseSearch/FEventData.cs
+++ b/CUE4Parse/UE4/Assets/Exports/Animation/PoseSearch/FEventData.cs
@@ -5,5 +5,5 @@ namespace CUE4Parse.UE4.Assets.Exports.Animation.PoseSearch;
 
 public class FEventData(FAssetArchive Ar)
 {
-    public Dictionary<FGameplayTag, int[]> Data = Ar.ReadMap(() => new FGameplayTag(Ar), Ar.ReadArray<int>);
+    public Dictionary<FGameplayTag, int[]> Data = Ar.ReadMap(() => new FGameplayTag(Ar), () => Ar.ReadArray<int>());
 }

--- a/CUE4Parse/UE4/Assets/Exports/Animation/USeqAct_Interp.cs
+++ b/CUE4Parse/UE4/Assets/Exports/Animation/USeqAct_Interp.cs
@@ -24,7 +24,7 @@ public class USeqAct_Interp : UObject
 
         if (Ar.Ver >= EUnrealEngineObjectUE3Version.ADDED_SEQACT_INTERP_SAVEACTORTRANSFORMS)
         {
-            SavedActorTransforms = Ar.ReadMap(() => new FPackageIndex(Ar), Ar.Read<FSavedTransform>);
+            SavedActorTransforms = Ar.ReadMap(() => new FPackageIndex(Ar), () => Ar.Read<FSavedTransform>());
         }
     }
 

--- a/CUE4Parse/UE4/Assets/Exports/AudioSynesthesia/UConstantQNRT.cs
+++ b/CUE4Parse/UE4/Assets/Exports/AudioSynesthesia/UConstantQNRT.cs
@@ -15,8 +15,8 @@ public class UConstantQNRT : UObject
         base.Deserialize(Ar, validPos);
         DurationInSeconds = Ar.Read<float>();
         bIsSortedChronologically = Ar.ReadBoolean();
-        ChannelCQTFrames = Ar.ReadMap(Ar.Read<int>, () => Ar.ReadArray(() => new FConstantQFrame(Ar)));
-        ChannelCQTIntervals = Ar.ReadMap(Ar.Read<int>, Ar.Read<FFloatInterval>);
+        ChannelCQTFrames = Ar.ReadMap(() => Ar.Read<int>(), () => Ar.ReadArray(() => new FConstantQFrame(Ar)));
+        ChannelCQTIntervals = Ar.ReadMap(() => Ar.Read<int>(), () => Ar.Read<FFloatInterval>());
     }
 
     protected internal override void WriteJson(JsonWriter writer, JsonSerializer serializer)

--- a/CUE4Parse/UE4/Assets/Exports/AudioSynesthesia/ULoudnessNRT.cs
+++ b/CUE4Parse/UE4/Assets/Exports/AudioSynesthesia/ULoudnessNRT.cs
@@ -16,8 +16,8 @@ public class ULoudnessNRT : UObject
         base.Deserialize(Ar, validPos);
         DurationInSeconds = Ar.Read<float>();
         bIsSortedChronologically = Ar.ReadBoolean();
-        ChannelLoudnessArrays = Ar.ReadMap(Ar.Read<int>, Ar.ReadArray<FLoudnessDatum>);
-        ChannelLoudnessIntervals = Ar.ReadMap(Ar.Read<int>, Ar.Read<FFloatInterval>);
+        ChannelLoudnessArrays = Ar.ReadMap(() => Ar.Read<int>(), () => Ar.ReadArray<FLoudnessDatum>());
+        ChannelLoudnessIntervals = Ar.ReadMap(() => Ar.Read<int>(), () => Ar.Read<FFloatInterval>());
     }
 
     protected internal override void WriteJson(JsonWriter writer, JsonSerializer serializer)

--- a/CUE4Parse/UE4/Assets/Exports/BuildData/UMapBuildDataRegistry.cs
+++ b/CUE4Parse/UE4/Assets/Exports/BuildData/UMapBuildDataRegistry.cs
@@ -30,20 +30,20 @@ public class UMapBuildDataRegistry : UObject
 
         if (!stripFlags.IsAudioVisualDataStripped())
         {
-            MeshBuildData = Ar.ReadMap(Ar.Read<FGuid>, () => new FMeshMapBuildData(Ar));
-            LevelPrecomputedLightVolumeBuildData = Ar.ReadMap(Ar.Read<FGuid>, () => new FPrecomputedLightVolumeData(Ar));
+            MeshBuildData = Ar.ReadMap(() => Ar.Read<FGuid>(), () => new FMeshMapBuildData(Ar));
+            LevelPrecomputedLightVolumeBuildData = Ar.ReadMap(() => Ar.Read<FGuid>(), () => new FPrecomputedLightVolumeData(Ar));
 
             if (FRenderingObjectVersion.Get(Ar) >= FRenderingObjectVersion.Type.VolumetricLightmaps)
             {
-                LevelPrecomputedVolumetricLightmapBuildData = Ar.ReadMap(Ar.Read<FGuid>, () => new FPrecomputedVolumetricLightmapData(Ar));
+                LevelPrecomputedVolumetricLightmapBuildData = Ar.ReadMap(() => Ar.Read<FGuid>(), () => new FPrecomputedVolumetricLightmapData(Ar));
             }
 
-            LightBuildData = Ar.ReadMap(Ar.Read<FGuid>, () => new FLightComponentMapBuildData(Ar));
+            LightBuildData = Ar.ReadMap(() => Ar.Read<FGuid>(), () => new FLightComponentMapBuildData(Ar));
             if (FReflectionCaptureObjectVersion.Get(Ar) >= FReflectionCaptureObjectVersion.Type.MoveReflectionCaptureDataToMapBuildData)
             {
                 if (Ar.Game is GAME_TheFirstDescendant) return;
                 if (Ar.Game is GAME_SilverPalace) Ar.SkipFixedArray(17);
-                ReflectionCaptureBuildData = Ar.ReadMap(Ar.Read<FGuid>, () => new FReflectionCaptureMapBuildData(Ar));
+                ReflectionCaptureBuildData = Ar.ReadMap(() => Ar.Read<FGuid>(), () => new FReflectionCaptureMapBuildData(Ar));
             }
 
             if (Ar.Game is GAME_ArenaBreakoutInfinite or GAME_ArenaBreakoutMobile) return;
@@ -56,7 +56,7 @@ public class UMapBuildDataRegistry : UObject
 
             if (FRenderingObjectVersion.Get(Ar) >= FRenderingObjectVersion.Type.SkyAtmosphereStaticLightingVersioning)
             {
-                SkyAtmosphereBuildData = Ar.ReadMap(Ar.Read<FGuid>, () => new FSkyAtmosphereMapBuildData(Ar));
+                SkyAtmosphereBuildData = Ar.ReadMap(() => Ar.Read<FGuid>(), () => new FSkyAtmosphereMapBuildData(Ar));
             }
 
             if (FFortniteMainBranchObjectVersion.Get(Ar) >= FFortniteMainBranchObjectVersion.Type.VolumetricLightMapGridDescSupport)

--- a/CUE4Parse/UE4/Assets/Exports/Component/Landscape/FLandscapeComponentGrassData.cs
+++ b/CUE4Parse/UE4/Assets/Exports/Component/Landscape/FLandscapeComponentGrassData.cs
@@ -21,7 +21,7 @@ public class FLandscapeComponentGrassData
         if (Ar.Game >= GAME_UE5_8)
         {
             NumElements = Ar.Read<int>();
-            WeightOffsetsNew = Ar.ReadMap(Ar.ReadFName, Ar.Read<int>);
+            WeightOffsetsNew = Ar.ReadMap(Ar.ReadFName, () => Ar.Read<int>());
             HeightWeightData = Ar.ReadArray<byte>();
             foreach (var kvp in WeightOffsetsNew)
             {
@@ -39,7 +39,7 @@ public class FLandscapeComponentGrassData
         else if (Ar.Game >= GAME_UE5_0)
         {
             NumElements = Ar.Read<int>();
-            WeightOffsets = Ar.ReadMap(() => new FPackageIndex(Ar), Ar.Read<int>);
+            WeightOffsets = Ar.ReadMap(() => new FPackageIndex(Ar), () => Ar.Read<int>());
             HeightWeightData = Ar.ReadArray<byte>();
         }
         else
@@ -78,7 +78,7 @@ public class FLandscapeComponentGrassData
             }
 
             HeightData = Ar.ReadBulkArray<ushort>();
-            WeightData = Ar.ReadMap(() => new FPackageIndex(Ar), Ar.ReadArray<byte>);
+            WeightData = Ar.ReadMap(() => new FPackageIndex(Ar), () => Ar.ReadArray<byte>());
         }
     }
 }

--- a/CUE4Parse/UE4/Assets/Exports/Component/StaticMesh/UInstancedStaticMeshComponent.cs
+++ b/CUE4Parse/UE4/Assets/Exports/Component/StaticMesh/UInstancedStaticMeshComponent.cs
@@ -35,7 +35,7 @@ public class UInstancedStaticMeshComponent : UStaticMeshComponent
             }
 
             Ar.SkipFixedArray(4);
-            PerInstanceSMCustomData = Ar.ReadBulkArray(Ar.Read<float>);
+            PerInstanceSMCustomData = Ar.ReadBulkArray(() => Ar.Read<float>());
             Ar.Position += Ar.Read<long>()+8;
             PerInstanceSMData = Ar.ReadBulkArray(() => new FInstancedStaticMeshInstanceData(Ar));
             return;
@@ -99,7 +99,7 @@ public class UInstancedStaticMeshComponent : UStaticMeshComponent
 
             if (FRenderingObjectVersion.Get(Ar) >= FRenderingObjectVersion.Type.PerInstanceCustomData || Ar.Game == GAME_DeltaForce)
             {
-                PerInstanceSMCustomData = Ar.ReadBulkArray(Ar.Read<float>);
+                PerInstanceSMCustomData = Ar.ReadBulkArray(() => Ar.Read<float>());
             }
         }
 

--- a/CUE4Parse/UE4/Assets/Exports/CustomizableObject/FModelStreamableBulkData.cs
+++ b/CUE4Parse/UE4/Assets/Exports/CustomizableObject/FModelStreamableBulkData.cs
@@ -13,11 +13,11 @@ public class FModelStreamableBulkData
 
     public FModelStreamableBulkData(FAssetArchive Ar)
     {
-        ModelStreamables = Ar.ReadMap(Ar.Read<uint>, () => new FMutableStreamableBlock(Ar));
+        ModelStreamables = Ar.ReadMap(() => Ar.Read<uint>(), () => new FMutableStreamableBlock(Ar));
         if (Ar.Game < GAME_UE5_8)
         {
-            ClothingStreamables = Ar.ReadMap(Ar.Read<uint>, () => new FClothingStreamable(Ar));
-            RealTimeMorphStreamables = Ar.ReadMap(Ar.Read<uint>, () => new FRealTimeMorphStreamable(Ar));
+            ClothingStreamables = Ar.ReadMap(() => Ar.Read<uint>(), () => new FClothingStreamable(Ar));
+            RealTimeMorphStreamables = Ar.ReadMap(() => Ar.Read<uint>(), () => new FRealTimeMorphStreamable(Ar));
         }
         StreamableBulkData = Ar.ReadArray(() => new FByteBulkData(Ar));
     }

--- a/CUE4Parse/UE4/Assets/Exports/CustomizableObject/Mutable/FProgram.cs
+++ b/CUE4Parse/UE4/Assets/Exports/CustomizableObject/Mutable/FProgram.cs
@@ -118,7 +118,7 @@ public class FProgram
             if (Ar.Game < GAME_UE5_7) ConstantPhysicsBodies = Ar.ReadPtrArray(() => new FPhysicsBody(Ar));
             Parameters = Ar.ReadArray(() => new FParameterDesc(Ar));
             Ranges = Ar.ReadArray(() => new FRangeDesc(Ar));
-            ParameterLists = Ar.ReadArray(Ar.ReadArray<ushort>);
+            ParameterLists = Ar.ReadArray(() => Ar.ReadArray<ushort>());
             return;
         }
         else
@@ -149,16 +149,16 @@ public class FProgram
         ConstantStrings = Ar.Game >= GAME_UE5_4 ? Ar.ReadArray(Ar.ReadFString) : Ar.ReadArray(Ar.ReadString);
         if (Ar.Game >= GAME_UE5_8)
         {
-            ConstantUInt32Lists = Ar.ReadArray(Ar.ReadArray<uint>);
-            ConstantInt32Lists = Ar.ReadArray(Ar.ReadArray<int>);
-            ConstantUInt64Lists = Ar.ReadArray(Ar.ReadArray<ulong>);
-            ConstantFloatLists = Ar.ReadArray(Ar.ReadArray<float>);
+            ConstantUInt32Lists = Ar.ReadArray(() => Ar.ReadArray<uint>());
+            ConstantInt32Lists = Ar.ReadArray(() => Ar.ReadArray<int>());
+            ConstantUInt64Lists = Ar.ReadArray(() => Ar.ReadArray<ulong>());
+            ConstantFloatLists = Ar.ReadArray(() => Ar.ReadArray<float>());
             ConstantBoolLists = Ar.ReadArray(() => Ar.ReadArray(Ar.ReadFlag));
         }
         else if (Ar.Game >= GAME_UE5_7)
         {
-            ConstantUInt32Lists = Ar.ReadArray(Ar.ReadArray<uint>);
-            ConstantUInt64Lists = Ar.ReadArray(Ar.ReadArray<ulong>);
+            ConstantUInt32Lists = Ar.ReadArray(() => Ar.ReadArray<uint>());
+            ConstantUInt64Lists = Ar.ReadArray(() => Ar.ReadArray<ulong>());
         }
         ConstantLayouts = Ar.ReadPtrArray(() => new FLayout(Ar));
         ConstantProjectors = Ar.ReadArray<FProjector>();
@@ -176,13 +176,13 @@ public class FProgram
         if (Ar.Game < GAME_UE5_7) ConstantPhysicsBodies = Ar.ReadPtrArray(() => new FPhysicsBody(Ar));
         Parameters = Ar.ReadArray(() => new FParameterDesc(Ar));
         Ranges = Ar.ReadArray(() => new FRangeDesc(Ar));
-        ParameterLists = Ar.ReadArray(Ar.ReadArray<ushort>);
-        if (Ar.Game >= GAME_UE5_8) RelevantParameterList = Ar.ReadMap(Ar.Read<uint>, Ar.Read<int>);
+        ParameterLists = Ar.ReadArray(() => Ar.ReadArray<ushort>());
+        if (Ar.Game >= GAME_UE5_8) RelevantParameterList = Ar.ReadMap(() => Ar.Read<uint>(), () => Ar.Read<int>());
         if (Ar.Game >= GAME_UE5_7) ConstantMaterials = Ar.ReadPtrArray(() => new FMaterial(Ar));
         if (Ar.Game >= GAME_UE5_8)
         {
-            ConstantNames = Ar.ReadMap(Ar.Read<uint>, Ar.ReadFName);
-            ConstantSockets = Ar.ReadMap(Ar.Read<uint>, () => new FMeshSocket(Ar));
+            ConstantNames = Ar.ReadMap(() => Ar.Read<uint>(), Ar.ReadFName);
+            ConstantSockets = Ar.ReadMap(() => Ar.Read<uint>(), () => new FMeshSocket(Ar));
         }
     }
 }

--- a/CUE4Parse/UE4/Assets/Exports/CustomizableObject/Mutable/Materials/FMaterial.cs
+++ b/CUE4Parse/UE4/Assets/Exports/CustomizableObject/Mutable/Materials/FMaterial.cs
@@ -15,7 +15,7 @@ public class FMaterial
     {
         ReferenceID = Ar.Game < GAME_UE5_8 ? Ar.Read<int>() : -1;
         ImageParameters = Ar.ReadMap(() => new FParameterKey(Ar), () => new FImageParameterData(Ar));
-        ColorParameters = Ar.ReadMap(() => new FParameterKey(Ar), Ar.Read<FVector4>);
-        ScalarParameters = Ar.ReadMap(() => new FParameterKey(Ar), Ar.Read<float>);
+        ColorParameters = Ar.ReadMap(() => new FParameterKey(Ar), () => Ar.Read<FVector4>());
+        ScalarParameters = Ar.ReadMap(() => new FParameterKey(Ar), () => Ar.Read<float>());
     }
 }

--- a/CUE4Parse/UE4/Assets/Exports/CustomizableObject/Mutable/Mesh/FMeshMorph.cs
+++ b/CUE4Parse/UE4/Assets/Exports/CustomizableObject/Mutable/Mesh/FMeshMorph.cs
@@ -26,7 +26,7 @@ public class FMeshMorph
         MinimumValuePerMorph = Ar.ReadArray<FVector4>();
         BatchStartOffsetPerMorph = Ar.ReadArray<uint>();
         BatchesPerMorph = Ar.ReadArray<uint>();
-        SurfacesInUsePerMorph = Ar.ReadArray(Ar.ReadArray<int>);
+        SurfacesInUsePerMorph = Ar.ReadArray(() => Ar.ReadArray<int>());
         UsageFlagsPerMorph = Ar.ReadArray<EMorphUsageFlags>();
         NumTotalBatches = Ar.Read<uint>();
         PositionPrecision = Ar.Read<float>();

--- a/CUE4Parse/UE4/Assets/Exports/Engine/Font/UFont.cs
+++ b/CUE4Parse/UE4/Assets/Exports/Engine/Font/UFont.cs
@@ -24,7 +24,7 @@ public class UFont : UObject
 
         if (Ar.Ver >= EUnrealEngineObjectUE3Version.Release69)
         {
-            CharRemap = Ar.ReadMap(Ar.Read<ushort>, Ar.Read<ushort>);
+            CharRemap = Ar.ReadMap(() => Ar.Read<ushort>(), () => Ar.Read<ushort>());
 
             if (Ar.Ver < EUnrealEngineObjectUE3Version.FIXED_FONTS_SERIALIZATION && Ar.Game < EGame.GAME_UE4_0)
             {

--- a/CUE4Parse/UE4/Assets/Exports/Engine/Font/UFontFace.cs
+++ b/CUE4Parse/UE4/Assets/Exports/Engine/Font/UFontFace.cs
@@ -56,7 +56,7 @@ public class FFontFaceData
 public class FPreprocessedFontGeometry(FArchive Ar)
 {
     public bool GlobalWindingReversal = Ar.ReadBoolean();
-    public Dictionary<int, FGlyphHeader> Glyphs = Ar.ReadMap(Ar.Read<int>, Ar.Read<FGlyphHeader>);
+    public Dictionary<int, FGlyphHeader> Glyphs = Ar.ReadMap(() => Ar.Read<int>(), () => Ar.Read<FGlyphHeader>());
     public byte[] ContourData = Ar.ReadArray<byte>();
     public short[] CoordinateData = Ar.ReadArray<short>();
 }

--- a/CUE4Parse/UE4/Assets/Exports/Engine/UGuidCache.cs
+++ b/CUE4Parse/UE4/Assets/Exports/Engine/UGuidCache.cs
@@ -12,7 +12,7 @@ public class UGuidCache : UObject
     {
         base.Deserialize(Ar, validPos);
 
-        PackageGuidMap = Ar.ReadMap(Ar.ReadFName, Ar.Read<FGuid>);
+        PackageGuidMap = Ar.ReadMap(Ar.ReadFName, () => Ar.Read<FGuid>());
     }
 
     protected internal override void WriteJson(JsonWriter writer, JsonSerializer serializer)

--- a/CUE4Parse/UE4/Assets/Exports/FastGeoStreaming/FFastGeoInstancedStaticMeshComponent.cs
+++ b/CUE4Parse/UE4/Assets/Exports/FastGeoStreaming/FFastGeoInstancedStaticMeshComponent.cs
@@ -42,7 +42,7 @@ public class FFastGeoInstancedStaticMeshComponent : FFastGeoStaticMeshComponentB
         
         LastInstanceBodyIndex = Ar.Game >= GAME_UE5_8 ? Ar.Read<int>() : 0;
         InstancingRandomSeed = Ar.Read<int>();
-        PerInstanceSMCustomData = Ar.ReadBulkArray(Ar.Read<float>);
+        PerInstanceSMCustomData = Ar.ReadBulkArray(() => Ar.Read<float>());
         AdditionalRandomSeeds = Ar.ReadArray<FInstancedStaticMeshRandomSeed>();
         if (Ar.Game is GAME_SilverPalace)
         {

--- a/CUE4Parse/UE4/Assets/Exports/NNE/UNNEModelData.cs
+++ b/CUE4Parse/UE4/Assets/Exports/NNE/UNNEModelData.cs
@@ -32,7 +32,7 @@ public class UNNEModelData : UObject
                 FileType = Ar.ReadFString();
                 FileData = Ar.ReadArray<byte>();
                 FileId = Ar.Read<FGuid>();
-                ModelData = Ar.ReadMap(Ar.ReadFString, Ar.ReadArray<byte>);
+                ModelData = Ar.ReadMap(Ar.ReadFString, () => Ar.ReadArray<byte>());
                 break;
             case NNEModelDataVersion.Type.V2:
                 TargetRuntimes = Ar.ReadArray(Ar.ReadFString);
@@ -53,7 +53,7 @@ public class UNNEModelData : UObject
                 TargetRuntimes = Ar.ReadArray(Ar.ReadFString);
                 FileType = Ar.ReadFString();
                 FileData = Ar.ReadArray<byte>();
-                AdditionalFileData = Ar.ReadMap(Ar.ReadFString, Ar.ReadArray<byte>);
+                AdditionalFileData = Ar.ReadMap(Ar.ReadFString, () => Ar.ReadArray<byte>());
                 FileId = Ar.Read<FGuid>();
                 numItems = Ar.Read<int>();
                 ModelData = [];

--- a/CUE4Parse/UE4/Assets/Exports/Niagara/FNiagaraShaderScript.cs
+++ b/CUE4Parse/UE4/Assets/Exports/Niagara/FNiagaraShaderScript.cs
@@ -19,7 +19,7 @@ public class FNiagaraShaderScript
         NumPermutations = Ar.Read<int>();
         if (Ar.Game is >= GAME_UE4_26 and < GAME_UE5_0)
         {
-            ShaderStageToPermutation = Ar.ReadMap(Ar.Read<int>, Ar.Read<int>);
+            ShaderStageToPermutation = Ar.ReadMap(() => Ar.Read<int>(), () => Ar.Read<int>());
         }
         if (Ar.Game >= GAME_UE5_2 || Ar.Game is GAME_DuetNightAbyss or GAME_HonorofKingsWorld)
         {

--- a/CUE4Parse/UE4/Assets/Exports/PCG/UPCGLandscapeCache.cs
+++ b/CUE4Parse/UE4/Assets/Exports/PCG/UPCGLandscapeCache.cs
@@ -17,7 +17,7 @@ public class UPCGLandscapeCache : UObject
     public override void Deserialize(FAssetArchive Ar, long validPos)
     {
         base.Deserialize(Ar, validPos);
-        CachedData = Ar.ReadMap(Ar.Read<CacheMapKey>, () => new FPCGLandscapeCacheEntry(Ar));
+        CachedData = Ar.ReadMap(() => Ar.Read<CacheMapKey>(), () => new FPCGLandscapeCacheEntry(Ar));
     }
 
     override protected internal void WriteJson(JsonWriter writer, JsonSerializer serializer)

--- a/CUE4Parse/UE4/Assets/Exports/Rig/LODMapping.cs
+++ b/CUE4Parse/UE4/Assets/Exports/Rig/LODMapping.cs
@@ -10,6 +10,6 @@ public class LODMapping
     public LODMapping(FArchiveBigEndian Ar)
     {
         LODs = Ar.ReadArray<ushort>();
-        Indices = Ar.ReadArray(Ar.ReadArray<ushort>);
+        Indices = Ar.ReadArray(() => Ar.ReadArray<ushort>());
     }
 }

--- a/CUE4Parse/UE4/Assets/Exports/Rig/RawMeshRegionMembership.cs
+++ b/CUE4Parse/UE4/Assets/Exports/Rig/RawMeshRegionMembership.cs
@@ -10,6 +10,6 @@ public class RawMeshRegionMembership
     public RawMeshRegionMembership(FArchiveBigEndian Ar)
     {
         RegionNames = Ar.ReadArray(() => Ar.ReadArray(Ar.ReadString));
-        Indices = Ar.ReadArray(() => Ar.ReadArray(Ar.ReadArray<ushort>));
+        Indices = Ar.ReadArray(() => Ar.ReadArray(() => Ar.ReadArray<ushort>()));
     }
 }

--- a/CUE4Parse/UE4/Assets/Exports/SkeletalMesh/FRuntimeSkinWeightProfileData.cs
+++ b/CUE4Parse/UE4/Assets/Exports/SkeletalMesh/FRuntimeSkinWeightProfileData.cs
@@ -27,6 +27,6 @@ public class FRuntimeSkinWeightProfileData
             NumWeightsPerVertex = Ar.Read<byte>();
         }
 
-        VertexIndexToInfluenceOffset = Ar.ReadMap(Ar.Read<uint>, Ar.Read<uint>);
+        VertexIndexToInfluenceOffset = Ar.ReadMap(() => Ar.Read<uint>(), () => Ar.Read<uint>());
     }
 }

--- a/CUE4Parse/UE4/Assets/Exports/Wwise/UAkAudioEvent.cs
+++ b/CUE4Parse/UE4/Assets/Exports/Wwise/UAkAudioEvent.cs
@@ -27,7 +27,7 @@ public class UAkAudioEvent : UAkAudioType
         IsInfinite = Ar.ReadBoolean();
         MaxAttenuationRadius = Ar.Read<float>();
 
-        if (Ar.Game is GAME_MortalKombat1) CustomGameData = Ar.ReadMap(Ar.Read<uint>, () => Ar.ReadMap(Ar.Read<uint>, Ar.Read<float>));
+        if (Ar.Game is GAME_MortalKombat1) CustomGameData = Ar.ReadMap(() => Ar.Read<uint>(), () => Ar.ReadMap(() => Ar.Read<uint>(), () => Ar.Read<float>()));
     }
 
     protected internal override void WriteJson(JsonWriter writer, JsonSerializer serializer)

--- a/CUE4Parse/UE4/Assets/Objects/Properties/FPropertyTagType.cs
+++ b/CUE4Parse/UE4/Assets/Objects/Properties/FPropertyTagType.cs
@@ -81,7 +81,14 @@ public abstract class FPropertyTagType
                 var search = storedEnum.SubstringAfter("::"); // Strip enum name on namespaced and enum class enums
                 var values = type.GetEnumNames();
                 var idx = Array.FindIndex(values, it => it == search);
-                return idx == -1 ? null : type.GetEnumValues().GetValue(idx);
+                if (idx == -1) return null;
+                // Type.GetEnumValues() builds an array of the enum type itself, which under
+                // NativeAOT throws unless ILC happened to generate that array type - rooting
+                // the assembly keeps the enum but not EFoo[]. Going through the underlying
+                // primitive sidesteps it: int[]/byte[] always have native code, and
+                // Enum.ToObject boxes back to the enum without needing its array type.
+                var underlying = Enum.GetValuesAsUnderlyingType(type).GetValue(idx);
+                return underlying is null ? null : Enum.ToObject(type, underlying);
             //TODO There are also Enums stored as ByteProperty but UModel uses them nowhere besides in UE2
             case FPropertyTagType<UScriptMap> mapProp when type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Dictionary<,>):
                 return CreateDictionary(type, mapProp.Value!.Properties);

--- a/CUE4Parse/UE4/BinaryConfig/Objects/FConfigFileHierarchy.cs
+++ b/CUE4Parse/UE4/BinaryConfig/Objects/FConfigFileHierarchy.cs
@@ -10,7 +10,7 @@ public class FConfigFileHierarchy
 
     public FConfigFileHierarchy(FArchive Ar)
     {
-        ConfigFileHierarchyMap = Ar.ReadMap(Ar.Read<int>, () => Ar.Game >= GAME_UE5_7 ? Ar.ReadFUtf8String() : Ar.ReadFString());
+        ConfigFileHierarchyMap = Ar.ReadMap(() => Ar.Read<int>(), () => Ar.Game >= GAME_UE5_7 ? Ar.ReadFUtf8String() : Ar.ReadFString());
         if (Ar.Game < GAME_UE5_8) KeyGen = Ar.Read<int>();
     }
 }

--- a/CUE4Parse/UE4/Objects/Chaos/FImplicitBVH.cs
+++ b/CUE4Parse/UE4/Objects/Chaos/FImplicitBVH.cs
@@ -59,7 +59,7 @@ public class TBoundingVolumeHierarchy<OBJECT_ARRAY, LEAF_TYPE, T> where T: struc
         MMaxLevels = Ar.Read<int>();
 
         Elements = Ar.ReadArray(() => new TBVHNode<T>(Ar, d));
-        Leafs = Ar.ReadArray(Ar.ReadArray<LEAF_TYPE>);
+        Leafs = Ar.ReadArray(() => Ar.ReadArray<LEAF_TYPE>());
     }
 }
 

--- a/CUE4Parse/UE4/Objects/Chaos/GeometryCollection/FValueType.cs
+++ b/CUE4Parse/UE4/Objects/Chaos/GeometryCollection/FValueType.cs
@@ -60,24 +60,24 @@ public readonly struct FValueType
         return ArrayType switch
         {
             EManagedArrayType.None => new FManagedArray<object>(() => null!),
-            EManagedArrayType.Vector => new FManagedArray<FVector>(Ar.Read<FVector>),
-            EManagedArrayType.IntVector => new FManagedArray<FIntVector>(Ar.Read<FIntVector>),
-            EManagedArrayType.Vector2D => new FManagedArray<FVector2D>(Ar.Read<FVector2D>),
-            EManagedArrayType.LinearColor => new FManagedArray<FLinearColor>(Ar.Read<FLinearColor>),
-            EManagedArrayType.Int32 => new FManagedArray<int>(Ar.Read<int>),
+            EManagedArrayType.Vector => new FManagedArray<FVector>(() => Ar.Read<FVector>()),
+            EManagedArrayType.IntVector => new FManagedArray<FIntVector>(() => Ar.Read<FIntVector>()),
+            EManagedArrayType.Vector2D => new FManagedArray<FVector2D>(() => Ar.Read<FVector2D>()),
+            EManagedArrayType.LinearColor => new FManagedArray<FLinearColor>(() => Ar.Read<FLinearColor>()),
+            EManagedArrayType.Int32 => new FManagedArray<int>(() => Ar.Read<int>()),
             EManagedArrayType.Bool => new FManagedArray<bool>(Ar.ReadFlag),
             EManagedArrayType.Transform => new FManagedArray<FTransform>(() => new FTransform(Ar)),
             EManagedArrayType.String => new FManagedArray<string>(Ar.ReadFString),
-            EManagedArrayType.Float => new FManagedArray<float>(Ar.Read<float>),
+            EManagedArrayType.Float => new FManagedArray<float>(() => Ar.Read<float>()),
             EManagedArrayType.Quat => new FManagedArray<FQuat>(() => new FQuat(Ar)),
             EManagedArrayType.BoneNode => new FManagedArray<FGeometryCollectionBoneNode>(() => new FGeometryCollectionBoneNode(Ar)),
             // UE 4.22
-            EManagedArrayType.MeshSection => new FManagedArray<FGeometryCollectionSection>(Ar.Read<FGeometryCollectionSection>),
+            EManagedArrayType.MeshSection => new FManagedArray<FGeometryCollectionSection>(() => Ar.Read<FGeometryCollectionSection>()),
             EManagedArrayType.Box => new FManagedArray<FBox>(() => new FBox(Ar)),
-            EManagedArrayType.IntArray => new FManagedArray<int[]>(Ar.ReadArray<int>), // This should be a TSet/HashSet
+            EManagedArrayType.IntArray => new FManagedArray<int[]>(() => Ar.ReadArray<int>()), // This should be a TSet/HashSet
             // UE 4.23
-            EManagedArrayType.Guid => new FManagedArray<FGuid>(Ar.Read<FGuid>),
-            EManagedArrayType.UInt8 => new FManagedArray<byte>(Ar.Read<byte>),
+            EManagedArrayType.Guid => new FManagedArray<FGuid>(() => Ar.Read<FGuid>()),
+            EManagedArrayType.UInt8 => new FManagedArray<byte>(() => Ar.Read<byte>()),
             // EManagedArrayType.VectorArrayPointer => expr,
             // EManagedArrayType.VectorArrayUniquePointer => expr,
             EManagedArrayType.FImplicitObject3Pointer => new FManagedArray<FImplicitObject?>(Ar.ReadPtr<FImplicitObject>),
@@ -95,29 +95,29 @@ public readonly struct FValueType
             // EManagedArrayType.TPBDRigidClusteredParticleHandle3fPtr => expr,
             // UE 5.0
             EManagedArrayType.FConvexUniquePtr => new FManagedArray<FConvex?>(Ar.ReadPtr<FConvex>),//or implicitObject
-            EManagedArrayType.Vector2DArray => new FManagedArray<FVector2D[]>(Ar.ReadArray<FVector2D>),
-            EManagedArrayType.Double => new FManagedArray<double>(Ar.Read<double>),
+            EManagedArrayType.Vector2DArray => new FManagedArray<FVector2D[]>(() => Ar.ReadArray<FVector2D>()),
+            EManagedArrayType.Double => new FManagedArray<double>(() => Ar.Read<double>()),
             // UE 5.1
             EManagedArrayType.IntVector4 => new FManagedArray<TIntVector4<int>>(Ar.Read<TIntVector4<int>>),
             EManagedArrayType.Vector3d => new FManagedArray<FVector>(() => new FVector(Ar)),
-            EManagedArrayType.IntVector2 => new FManagedArray<FIntVector2>(Ar.Read<FIntVector2>),
-            EManagedArrayType.IntVector2Array => new FManagedArray<FIntVector2[]>(Ar.ReadArray<FIntVector2>),
-            EManagedArrayType.Int32Array => new FManagedArray<int[]>(Ar.ReadArray<int>),
-            EManagedArrayType.FloatArray => new FManagedArray<float[]>(Ar.ReadArray<float>),
-            EManagedArrayType.Vector4f => new FManagedArray<FVector4>(Ar.Read<FVector4>),
-            EManagedArrayType.FVectorArray => new FManagedArray<FVector[]>(Ar.ReadArray<FVector>),
+            EManagedArrayType.IntVector2 => new FManagedArray<FIntVector2>(() => Ar.Read<FIntVector2>()),
+            EManagedArrayType.IntVector2Array => new FManagedArray<FIntVector2[]>(() => Ar.ReadArray<FIntVector2>()),
+            EManagedArrayType.Int32Array => new FManagedArray<int[]>(() => Ar.ReadArray<int>()),
+            EManagedArrayType.FloatArray => new FManagedArray<float[]>(() => Ar.ReadArray<float>()),
+            EManagedArrayType.Vector4f => new FManagedArray<FVector4>(() => Ar.Read<FVector4>()),
+            EManagedArrayType.FVectorArray => new FManagedArray<FVector[]>(() => Ar.ReadArray<FVector>()),
             // UE 5.2
             // EManagedArrayType.TPBDRigidParticle3fUniquePtr => expr,
             // UE 5.4
             EManagedArrayType.FImplicitObjectRefCountedPtr => new FManagedArray<FImplicitObject?>(Ar.ReadPtr<FImplicitObject>),
             EManagedArrayType.FConvexRefCountedPtr => new FManagedArray<FConvex?>(Ar.ReadPtr<FConvex>),
-            EManagedArrayType.Transform3f => new FManagedArray<FTransform>(Ar.Read<FTransform>),
+            EManagedArrayType.Transform3f => new FManagedArray<FTransform>(() => Ar.Read<FTransform>()),
             EManagedArrayType.IntVector3Array => new FManagedArray<TIntVector3<int>>(Ar.Read<TIntVector3<int>>),
-            EManagedArrayType.Vector4fArray => new FManagedArray<FVector4[]>(Ar.ReadArray<FVector4>),
+            EManagedArrayType.Vector4fArray => new FManagedArray<FVector4[]>(() => Ar.ReadArray<FVector4>()),
             // UE 5.5
             EManagedArrayType.PMatrix33d => new FManagedArray<FMatrix>(() => new FMatrix(Ar)),
             EManagedArrayType.PMatrix33dArray => new FManagedArray<FMatrix[]>(() => Ar.ReadArray(() => new FMatrix(Ar))),
-            EManagedArrayType.FVector3fNestedArray => new FManagedArray<FVector[][]>(() => Ar.ReadArray(Ar.ReadArray<FVector>)),
+            EManagedArrayType.FVector3fNestedArray => new FManagedArray<FVector[][]>(() => Ar.ReadArray(() => Ar.ReadArray<FVector>())),
             // UE 5.6
             EManagedArrayType.UintVector2 => new FManagedArray<TIntVector2<uint>>(Ar.Read<TIntVector2<uint>>),
             EManagedArrayType.UObjectArray => new FManagedArray<FPackageIndex>(() => new FPackageIndex(Ar)),

--- a/CUE4Parse/UE4/Objects/Chaos/TBox.cs
+++ b/CUE4Parse/UE4/Objects/Chaos/TBox.cs
@@ -30,5 +30,5 @@ public sealed class TBox<T> : FImplicitObject where T : struct
         }
     }
 
-    public static Dictionary<int, TAABB<T>> SerializeAsAABBs(FChaosArchive Ar, int dimensions) => Ar.ReadMap(Ar.Read<int>, () => SerializeAsAABB(Ar, dimensions));
+    public static Dictionary<int, TAABB<T>> SerializeAsAABBs(FChaosArchive Ar, int dimensions) => Ar.ReadMap(() => Ar.Read<int>(), () => SerializeAsAABB(Ar, dimensions));
 }

--- a/CUE4Parse/UE4/Objects/ControlRig/RigHierarchyElements.cs
+++ b/CUE4Parse/UE4/Objects/ControlRig/RigHierarchyElements.cs
@@ -549,7 +549,7 @@ public struct FRigControlSettings
         FilteredChannels = [];
         if (FControlRigObjectVersion.Get(Ar) >= FControlRigObjectVersion.Type.ControlTransformChannelFiltering)
         {
-            FilteredChannels = Ar.ReadArray(Ar.Read<ERigControlTransformChannel>);
+            FilteredChannels = Ar.ReadArray(() => Ar.Read<ERigControlTransformChannel>());
         }
 
         PreferredRotationOrder = EEulerRotationOrder.YZX;

--- a/CUE4Parse/UE4/Objects/Engine/PerQualityLevelProperties.cs
+++ b/CUE4Parse/UE4/Objects/Engine/PerQualityLevelProperties.cs
@@ -14,7 +14,7 @@ public class FPerQualityLevelProperty<T> : IUStruct where T : struct
     {
         bCooked = Ar.ReadBoolean();
         Default = Ar.Read<T>();
-        PerQuality = Ar.ReadMap(Ar.Read<int>, Ar.Read<T>);
+        PerQuality = Ar.ReadMap(() => Ar.Read<int>(), () => Ar.Read<T>());
     }
 }
 

--- a/CUE4Parse/UE4/Objects/Engine/TPerPlatformProperty.cs
+++ b/CUE4Parse/UE4/Objects/Engine/TPerPlatformProperty.cs
@@ -31,23 +31,28 @@ public class FPerPlatformBool : TPerPlatformProperty<bool>
     public FPerPlatformBool(FAssetArchive Ar) : base(Ar, Ar.ReadBoolean) { }
 }
 
+// Read<T> is a generic virtual method. Passing it as a method group (Ar.Read<FFrameRate>)
+// builds the delegate through runtime GVM resolution, which NativeAOT cannot do for an
+// instantiation it never generated - and it FailFasts the process rather than throwing.
+// Wrapping the call in a lambda makes the instantiation a static call site that ILC sees
+// and generates, which costs nothing under JIT.
 public class FPerPlatformFloat : TPerPlatformProperty<float>
 {
     public FPerPlatformFloat() { }
     public FPerPlatformFloat(float value) { Default = value; }
-    public FPerPlatformFloat(FAssetArchive Ar) : base(Ar, Ar.Read<float>) { }
+    public FPerPlatformFloat(FAssetArchive Ar) : base(Ar, () => Ar.Read<float>()) { }
 }
 
 public class FPerPlatformInt : TPerPlatformProperty<int>
 {
     public FPerPlatformInt() { }
-    public FPerPlatformInt(FAssetArchive Ar) : base(Ar, Ar.Read<int>) { }
+    public FPerPlatformInt(FAssetArchive Ar) : base(Ar, () => Ar.Read<int>()) { }
 }
 
 public class FPerPlatformFrameRate : TPerPlatformProperty<FFrameRate>
 {
     public FPerPlatformFrameRate() { }
-    public FPerPlatformFrameRate(FAssetArchive Ar) : base(Ar, Ar.Read<FFrameRate>) { }
+    public FPerPlatformFrameRate(FAssetArchive Ar) : base(Ar, () => Ar.Read<FFrameRate>()) { }
 }
 
 public class FPerPlatformFString : TPerPlatformProperty<string>

--- a/CUE4Parse/UE4/Objects/LevelSequence/FLevelSequenceObjectReferenceMap.cs
+++ b/CUE4Parse/UE4/Objects/LevelSequence/FLevelSequenceObjectReferenceMap.cs
@@ -11,7 +11,7 @@ public readonly struct FLevelSequenceObjectReferenceMap : IUStruct, IReadOnlyDic
 
     public FLevelSequenceObjectReferenceMap(FArchive Ar)
     {
-        Map = Ar.ReadMap(Ar.Read<FGuid>, () => new FLevelSequenceLegacyObjectReference(Ar));
+        Map = Ar.ReadMap(() => Ar.Read<FGuid>(), () => new FLevelSequenceLegacyObjectReference(Ar));
     }
 
     public FLevelSequenceLegacyObjectReference this[FGuid key] => Map[key];

--- a/CUE4Parse/UE4/Objects/MovieScene/FMovieSceneTrackFieldData.cs
+++ b/CUE4Parse/UE4/Objects/MovieScene/FMovieSceneTrackFieldData.cs
@@ -4,5 +4,5 @@ namespace CUE4Parse.UE4.Objects.MovieScene;
 
 public readonly struct FMovieSceneTrackFieldData(FAssetArchive Ar) : IUStruct
 {
-    public readonly TMovieSceneEvaluationTree<uint> Field = new(Ar, Ar.Read<uint>);
+    public readonly TMovieSceneEvaluationTree<uint> Field = new(Ar, () => Ar.Read<uint>());
 }

--- a/CUE4Parse/UE4/Objects/PCG/FPCGMetadataAttribute.cs
+++ b/CUE4Parse/UE4/Objects/PCG/FPCGMetadataAttribute.cs
@@ -39,7 +39,7 @@ public abstract class FPCGMetadataAttributeBase
 
     public FPCGMetadataAttributeBase(FAssetArchive Ar)
     {
-        EntryToValueKeyMap = Ar.ReadMap(Ar.Read<long>, Ar.Read<int>);
+        EntryToValueKeyMap = Ar.ReadMap(() => Ar.Read<long>(), () => Ar.Read<int>());
         ParentAttributeId = Ar.Read<int>();
         Name = Ar.ReadFName();
         AttributeId = Ar.Read<int>();
@@ -50,10 +50,10 @@ public abstract class FPCGMetadataAttributeBase
         var attributeTypeId = Ar.Read<int>();
         FPCGMetadataAttributeBase attribute = attributeTypeId switch
         {
-            0 => new FPCGMetadataAttribute<float>(Ar, Ar.Read<float>),
-            1 => new FPCGMetadataAttribute<double>(Ar, Ar.Read<double>),
-            2 => new FPCGMetadataAttribute<int>(Ar, Ar.Read<int>),
-            3 => new FPCGMetadataAttribute<long>(Ar, Ar.Read<long>),
+            0 => new FPCGMetadataAttribute<float>(Ar, () => Ar.Read<float>()),
+            1 => new FPCGMetadataAttribute<double>(Ar, () => Ar.Read<double>()),
+            2 => new FPCGMetadataAttribute<int>(Ar, () => Ar.Read<int>()),
+            3 => new FPCGMetadataAttribute<long>(Ar, () => Ar.Read<long>()),
             4 => new FPCGMetadataAttribute<FVector2D>(Ar, () => new FVector2D(Ar)),
             5 => new FPCGMetadataAttribute<FVector>(Ar, () => new FVector(Ar)),
             6 => new FPCGMetadataAttribute<FVector4>(Ar, () => new FVector4(Ar)),

--- a/CUE4Parse/UE4/Objects/RigVM/FRigVMFunctionCompilationData.cs
+++ b/CUE4Parse/UE4/Objects/RigVM/FRigVMFunctionCompilationData.cs
@@ -36,11 +36,11 @@ public class FRigVMFunctionCompilationData
         ExternalPropertyDescriptions = Ar.ReadArray(() => new FRigVMFunctionCompilationPropertyDescription(Ar));
         ExternalPropertyPathDescriptions = Ar.ReadArray(() => new FRigVMFunctionCompilationPropertyPath(Ar));
 
-        ExternalRegisterIndexToVariable = Ar.ReadMap(Ar.Read<int>, Ar.ReadFName);
-        Operands = Ar.ReadMap(Ar.ReadFString, Ar.Read<FRigVMOperand>);
+        ExternalRegisterIndexToVariable = Ar.ReadMap(() => Ar.Read<int>(), Ar.ReadFName);
+        Operands = Ar.ReadMap(Ar.ReadFString, () => Ar.Read<FRigVMOperand>());
         if (FRigVMObjectVersion.Get(Ar) >= FRigVMObjectVersion.Type.RigVMCallables)
         {
-            InterfaceOperands = Ar.ReadMap(Ar.ReadFName, Ar.Read<FRigVMOperand>);
+            InterfaceOperands = Ar.ReadMap(Ar.ReadFName, () => Ar.Read<FRigVMOperand>());
         }
         Hash = Ar.Read<uint>();
         bEncounteredSurpressedErrors = false;
@@ -49,6 +49,6 @@ public class FRigVMFunctionCompilationData
             FFortniteMainBranchObjectVersion.Get(Ar) < FFortniteMainBranchObjectVersion.Type.RigVMSaveDebugMapInGraphFunctionData)
             return;
         if (FRigVMObjectVersion.Get(Ar) < FRigVMObjectVersion.Type.DebugOperandMappingSimplified)
-            OperandToDebugRegisters = Ar.ReadMap(Ar.Read<byte>(), Ar.Read<FRigVMOperand>, () => Ar.ReadArray(Ar.Read<byte>(), Ar.Read<FRigVMOperand>));
+            OperandToDebugRegisters = Ar.ReadMap(Ar.Read<byte>(), () => Ar.Read<FRigVMOperand>(), () => Ar.ReadArray(Ar.Read<byte>(), () => Ar.Read<FRigVMOperand>()));
     }
 }

--- a/CUE4Parse/UE4/Objects/RigVM/FRigVMGraphFunctionHeader.cs
+++ b/CUE4Parse/UE4/Objects/RigVM/FRigVMGraphFunctionHeader.cs
@@ -44,7 +44,7 @@ public class FRigVMGraphFunctionHeader
         Category = Ar.ReadFString();
         Keywords = Ar.ReadFString();
         Arguments = Ar.ReadArray(() => new FRigVMGraphFunctionArgument(Ar));
-        Dependencies = Ar.ReadMap(() => new FRigVMGraphFunctionIdentifier(Ar), Ar.Read<uint>);
+        Dependencies = Ar.ReadMap(() => new FRigVMGraphFunctionIdentifier(Ar), () => Ar.Read<uint>());
         ExternalVariables = Ar.ReadArray(() => new FRigVMExternalVariable(Ar));
 
         if (FRigVMObjectVersion.Get(Ar) >= FRigVMObjectVersion.Type.FunctionHeaderStoresLayout)

--- a/CUE4Parse/UE4/Objects/RigVM/FRigVMGraphFunctionStore.cs
+++ b/CUE4Parse/UE4/Objects/RigVM/FRigVMGraphFunctionStore.cs
@@ -22,7 +22,7 @@ public struct FRigVMGraphFunctionData
         SerializedCollapsedNode = Ar.ReadFString();
 
         if (Ar.Game >= GAME_UE5_8) // can't find anything in source, but it's there for FN
-            Ar.ReadMap(Ar.Read<FGuid>, Ar.Read<int>);
+            Ar.ReadMap(() => Ar.Read<FGuid>(), () => Ar.Read<int>());
 
         if (FRigVMObjectVersion.Get(Ar) < FRigVMObjectVersion.Type.RigVMSaveSerializedGraphInGraphFunctionDataAsByteArray)
             return;

--- a/CUE4Parse/UE4/Objects/RigVM/FRigVMNodeLayout.cs
+++ b/CUE4Parse/UE4/Objects/RigVM/FRigVMNodeLayout.cs
@@ -40,7 +40,7 @@ public struct FRigVMNodeLayout
         }
         else
         {
-            PinIndexInCategory = Ar.ReadMap(Ar.ReadFString, Ar.Read<int>);
+            PinIndexInCategory = Ar.ReadMap(Ar.ReadFString, () => Ar.Read<int>());
         }
         DisplayNames = Ar.ReadMap(Ar.ReadFString, Ar.ReadFString);
     }

--- a/CUE4Parse/UE4/Objects/RigVM/URigVM.cs
+++ b/CUE4Parse/UE4/Objects/RigVM/URigVM.cs
@@ -55,7 +55,7 @@ public class URigVM : Assets.Exports.UObject
                 if (FUE5ReleaseStreamObjectVersion.Get(Ar) >= FUE5ReleaseStreamObjectVersion.Type.RigVMSaveDebugMapInGraphFunctionData
                     || FFortniteMainBranchObjectVersion.Get(Ar) >= FFortniteMainBranchObjectVersion.Type.RigVMSaveDebugMapInGraphFunctionData)
                 {
-                    OperandToDebugRegisters = Ar.ReadMap(Ar.Read<FRigVMOperand>, () => Ar.ReadArray(Ar.Read<FRigVMOperand>));
+                    OperandToDebugRegisters = Ar.ReadMap(() => Ar.Read<FRigVMOperand>(), () => Ar.ReadArray(() => Ar.Read<FRigVMOperand>()));
                 }
 
                 if (FRigVMObjectVersion.Get(Ar) >= FRigVMObjectVersion.Type.VMStoringUserDefinedStructMap
@@ -88,7 +88,7 @@ public class URigVM : Assets.Exports.UObject
             FFortniteMainBranchObjectVersion.Get(Ar) >= FFortniteMainBranchObjectVersion.Type.RigVMSaveDebugMapInGraphFunctionData)
         {
             if (FRigVMObjectVersion.Get(Ar) < FRigVMObjectVersion.Type.DebugOperandMappingSimplified)
-                OperandToDebugRegisters = Ar.ReadMap(Ar.Read<FRigVMOperand>, () => Ar.ReadArray(Ar.Read<FRigVMOperand>));
+                OperandToDebugRegisters = Ar.ReadMap(() => Ar.Read<FRigVMOperand>(), () => Ar.ReadArray(() => Ar.Read<FRigVMOperand>()));
         }
 
         if (FRigVMObjectVersion.Get(Ar) >= FRigVMObjectVersion.Type.VMStoringUserDefinedStructMap &&

--- a/CUE4Parse/UE4/Objects/StructUtils/FInstancedPropertyBag.cs
+++ b/CUE4Parse/UE4/Objects/StructUtils/FInstancedPropertyBag.cs
@@ -156,6 +156,6 @@ public struct FPropertyBagContainerTypes
 
     public FPropertyBagContainerTypes(FAssetArchive Ar)
     {
-        Types = Ar.ReadArray(Ar.Read<byte>(), Ar.Read<EPropertyBagContainerType>);
+        Types = Ar.ReadArray(Ar.Read<byte>(), () => Ar.Read<EPropertyBagContainerType>());
     }
 }

--- a/CUE4Parse/UE4/Objects/UObject/UClass.cs
+++ b/CUE4Parse/UE4/Objects/UObject/UClass.cs
@@ -68,7 +68,7 @@ public class UClass : UStruct
         }
 
         ClassDefaultObject = new FPackageIndex(Ar);
-        if (Ar.Game == GAME_Borderlands4) _ = Ar.ReadMap(Ar.Read<ulong>, Ar.Read<int>);
+        if (Ar.Game == GAME_Borderlands4) _ = Ar.ReadMap(() => Ar.Read<ulong>(), () => Ar.Read<int>());
     }
 
     public Assets.Exports.UObject? ConstructObject(EObjectFlags flags)

--- a/CUE4Parse/UE4/Pak/PakFileReader.cs
+++ b/CUE4Parse/UE4/Pak/PakFileReader.cs
@@ -600,7 +600,7 @@ public partial class PakFileReader : AbstractAesVfsReader
             Ar.ReadFString,
             () => Ar.ReadTMap(
                 Ar.ReadFString,
-                Ar.Read<int>,
+                () => Ar.Read<int>(),
                 16, 4
             ),
             16, 56

--- a/CUE4Parse/UE4/Wwise/Objects/AkAuxParams.cs
+++ b/CUE4Parse/UE4/Wwise/Objects/AkAuxParams.cs
@@ -41,7 +41,7 @@ public readonly struct AkAuxParams
 
         if (hasAux)
         {
-            AuxIds = Ar.ReadArray(4, Ar.Read<uint>);
+            AuxIds = Ar.ReadArray(4, () => Ar.Read<uint>());
         }
 
         if (Ar.Version > 134)

--- a/CUE4Parse/UE4/Wwise/Objects/AkPropBundle.cs
+++ b/CUE4Parse/UE4/Wwise/Objects/AkPropBundle.cs
@@ -11,7 +11,7 @@ public readonly struct AkPropBundle(FWwiseArchive Ar)
     public static AkProp[] ReadSequentialAkProp(FWwiseArchive Ar)
     {
         int propCount = Ar.Read<byte>();
-        var ids = Ar.ReadArray(propCount, Ar.Read<byte>);
+        var ids = Ar.ReadArray(propCount, () => Ar.Read<byte>());
 
         var props = new AkProp[propCount];
         for (int i = 0; i < propCount; i++)
@@ -23,7 +23,7 @@ public readonly struct AkPropBundle(FWwiseArchive Ar)
     public static AkPropRange[] ReadSequentialAkPropRange(FWwiseArchive Ar)
     {
         int propCount = Ar.Read<byte>();
-        var ids = Ar.ReadArray(propCount, Ar.Read<byte>);
+        var ids = Ar.ReadArray(propCount, () => Ar.Read<byte>());
 
         var ranges = new AkPropRange[propCount];
         for (int i = 0; i < propCount; i++)

--- a/CUE4Parse/UE4/Wwise/Plugins/MasteringSuite/CMasteringSuiteFXParams.cs
+++ b/CUE4Parse/UE4/Wwise/Plugins/MasteringSuite/CMasteringSuiteFXParams.cs
@@ -12,7 +12,7 @@ public struct MasteringSuiteFXParams(FWwiseArchive Ar)
     public bool[] moduleBypassFlags = Ar.ReadArray(4, () => Ar.Read<byte>() != 0);
     public SceAudioOut2MasteringParamEqParamsV2 paramEqParams = new SceAudioOut2MasteringParamEqParamsV2(Ar);
     public SceAudioOut2MasteringCompressorParamsV2 compressorParams = new SceAudioOut2MasteringCompressorParamsV2(Ar);
-    public float[] masterVolumeParams = Ar.ReadArray(12, Ar.Read<float>);
+    public float[] masterVolumeParams = Ar.ReadArray(12, () => Ar.Read<float>());
     public SceAudioOut2MasteringLimiterParamsV2 limiterParams = new SceAudioOut2MasteringLimiterParamsV2(Ar);
 };
 
@@ -50,7 +50,7 @@ public struct SceAudioOut2MasteringCompressorParamsV2(FWwiseArchive Ar)
     public float linkStrength = Ar.Read<float>();
     public bool linkStereoPairs = Ar.Read<byte>() != 0;
     public bool[] bandsBypassFlags = Ar.ReadArray(4, () => Ar.Read<byte>() != 0);
-    public float[] crossoverFrequencies = Ar.ReadArray(3, Ar.Read<float>);
+    public float[] crossoverFrequencies = Ar.ReadArray(3, () => Ar.Read<float>());
     public SceAudioOut2MasteringCompressorBandParams[] bandParams = Ar.ReadArray<SceAudioOut2MasteringCompressorBandParams>(4);
 };
 

--- a/CUE4Parse/UE4/Wwise/WwiseReader.cs
+++ b/CUE4Parse/UE4/Wwise/WwiseReader.cs
@@ -113,11 +113,11 @@ public class WwiseReader
                     break;
                 case EChunkID.BankInit:
                     LoadedSize += sectionLength;
-                    AKPluginList = Ar.ReadMap(Ar.Read<uint>, () => Ar.Version <= 136 ? Ar.ReadFString() : Ar.ReadStzString());
+                    AKPluginList = Ar.ReadMap(() => Ar.Read<uint>(), () => Ar.Version <= 136 ? Ar.ReadFString() : Ar.ReadStzString());
                     break;
                 case EChunkID.BankDataIndex:
                     LoadedSize += sectionLength;
-                    WemIndexes = Ar.ReadArray(sectionLength / 12, Ar.Read<MediaHeader>);
+                    WemIndexes = Ar.ReadArray(sectionLength / 12, () => Ar.Read<MediaHeader>());
                     break;
                 case EChunkID.BankData:
                     if (WemIndexes == null)
@@ -147,8 +147,8 @@ public class WwiseReader
                     break;
                 case EChunkID.BankStrMap:
                     LoadedSize += sectionLength;
-                    Ar.Position += 4; //var type = Ar.Read<AKBKStringType>;
-                    BankIDToFileName = Ar.ReadMap(Ar.Read<uint>, Ar.ReadString);
+                    Ar.Position += 4; //var type = () => Ar.Read<AKBKStringType>();
+                    BankIDToFileName = Ar.ReadMap(() => Ar.Read<uint>(), Ar.ReadString);
                     break;
                 case EChunkID.BankStateMg:
                     if (Ar.IsSupported()) // Let's guard this just in case


### PR DESCRIPTION
looks silly but this has to be done,so ILC sees the lambda as a static call site and compiles it ahead of time.
alternative is a hard runtime crash whenever this is encountered when compiling via NativeAOT.
some more fixes have to be done in certain parts to make cue4parse fully NativeAOT compliant but this works for now.