### PR TITLE
Fix ExportSession UObject retention (#413)

### DIFF
--- a/CUE4Parse-Conversion/ExportSession.cs
+++ b/CUE4Parse-Conversion/ExportSession.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
+using System.Threading.Channels;
 using CUE4Parse.UE4.Assets.Exports;
 using CUE4Parse.UE4.Assets.Exports.Actor;
 using CUE4Parse.UE4.Assets.Exports.Animation;
@@ -38,38 +39,64 @@ public sealed class ExportSession(Action<StreamingLevelFilterArgs, CancellationT
     private int _running;
     public bool IsRunning => Volatile.Read(ref _running) == 1;
 
-    private readonly ConcurrentQueue<IExporter> _roots = new();
-    private readonly ConcurrentDictionary<string, byte> _paths = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Channel<QueueEntry> _queue = Channel.CreateUnbounded<QueueEntry>(new UnboundedChannelOptions
+    {
+        SingleReader = false,
+        SingleWriter = false,
+        AllowSynchronousContinuations = false
+    });
+    private readonly ConcurrentDictionary<string, QueueEntry> _entries = new(StringComparer.OrdinalIgnoreCase);
 
+    /// <summary>
+    /// Queues a built-in exporter for an Unreal object. Provider-backed package exports are held weakly and
+    /// reloaded if necessary, allowing their package data to be collected while the session is waiting to run.
+    /// Use <see cref="Add(ExporterBase)"/> when the exact in-memory object must remain alive.
+    /// </summary>
     public ExportSession Add(UObject export)
+    {
+        var exporter = CreateExporter(export);
+        return Add(DeferredObjectExporter.TryCreate(export) ?? exporter);
+    }
+
+    internal static ExporterBase CreateExporter(UObject export)
     {
         return export switch
         {
-            UTexture texture => Add(new TextureExporter(texture)),
-            UMaterialInterface material => Add(new MaterialExporter(material)),
-            USkeletalMesh skeletalMesh => Add(new SkeletalMeshExporter(skeletalMesh)),
-            UStaticMesh staticMesh => Add(new StaticMeshExporter(staticMesh)),
-            USkeleton skeleton => Add(new SkeletonExporter(skeleton)),
-            UPoseAsset poseAsset => Add(new PoseAssetExporter(poseAsset)),
-            UAnimationAsset animation => Add(new AnimationExporter(animation)),
-            UDNAAsset dna => Add(new DnaExporter(dna)),
-            UWorld world => Add(new WorldExporter(world)),
-            ALandscapeProxy landscape => Add(new LandscapeMeshExporter(landscape)),
-            ULandscapeComponent landscape => Add(new LandscapeMeshExporter2(landscape)),
-            USplineMeshComponent spline => Add(new SplineMeshExporter(spline)),
+            UTexture texture => new TextureExporter(texture),
+            UMaterialInterface material => new MaterialExporter(material),
+            USkeletalMesh skeletalMesh => new SkeletalMeshExporter(skeletalMesh),
+            UStaticMesh staticMesh => new StaticMeshExporter(staticMesh),
+            USkeleton skeleton => new SkeletonExporter(skeleton),
+            UPoseAsset poseAsset => new PoseAssetExporter(poseAsset),
+            UAnimationAsset animation => new AnimationExporter(animation),
+            UDNAAsset dna => new DnaExporter(dna),
+            UWorld world => new WorldExporter(world),
+            ALandscapeProxy landscape => new LandscapeMeshExporter(landscape),
+            ULandscapeComponent landscape => new LandscapeMeshExporter2(landscape),
+            USplineMeshComponent spline => new SplineMeshExporter(spline),
             _ => throw new NotSupportedException($"Could not create exporter for export of type '{export.GetType().Name}'.")
         };
     }
 
+    /// <summary>
+    /// Queues a preconfigured exporter. The exporter is strongly referenced until it is processed, removed,
+    /// or the session is cleared.
+    /// </summary>
     public ExportSession Add(ExporterBase exporter)
     {
         // TODO: this prevents 2 exporters messing with the same file from being enqueued in the same run (e.g. MeshExporter / RawDataExporter)
-        if (!_paths.TryAdd(exporter.ObjectPath, 0)) return this;
+        var entry = new QueueEntry(exporter);
+        if (!_entries.TryAdd(exporter.ObjectPath, entry)) return this;
 
         exporter._session = this;
-        _roots.Enqueue(exporter);
-
         Interlocked.Increment(ref _totalQueued);
+        if (!_queue.Writer.TryWrite(entry))
+        {
+            _entries.TryRemove(exporter.ObjectPath, out _);
+            Interlocked.Decrement(ref _totalQueued);
+            throw new InvalidOperationException("The export queue is not accepting new items.");
+        }
+
         OnPropertyChanged(nameof(TotalQueued));
         OnPropertyChanged(nameof(HasQueuedItems));
         exporter.Log.Debug("Queued for export");
@@ -78,10 +105,10 @@ public sealed class ExportSession(Action<StreamingLevelFilterArgs, CancellationT
 
     public bool Remove(string objectPath)
     {
-        // the exporter stays in _roots but we won't process it, it's fine because nothing actually relies on _roots.Count
-        if (IsRunning || !_paths.TryRemove(objectPath, out _))
+        if (IsRunning || !_entries.TryRemove(objectPath, out var entry))
             return false;
 
+        entry.Take();
         Interlocked.Decrement(ref _totalQueued);
         OnPropertyChanged(nameof(TotalQueued));
         OnPropertyChanged(nameof(HasQueuedItems));
@@ -90,8 +117,8 @@ public sealed class ExportSession(Action<StreamingLevelFilterArgs, CancellationT
 
     public void Clear()
     {
-        _roots.Clear();
-        _paths.Clear();
+        while (_queue.Reader.TryRead(out _)) { }
+        _entries.Clear();
         Interlocked.Exchange(ref _totalQueued, 0);
         OnPropertyChanged(nameof(TotalQueued));
         OnPropertyChanged(nameof(HasQueuedItems));
@@ -109,20 +136,50 @@ public sealed class ExportSession(Action<StreamingLevelFilterArgs, CancellationT
         var results = new ConcurrentQueue<ExportResult>();
         try
         {
-            var parallelOptions = new ParallelOptions { MaxDegreeOfParallelism = MaxDegreeOfParallelism, CancellationToken = ct };
-            var current = new List<IExporter>();
-            while (true)
+            var parallelOptions = new ParallelOptions
             {
-                current.Clear();
-                while (_roots.TryDequeue(out var exporter))
-                {
-                    ct.ThrowIfCancellationRequested();
-                    if (_paths.ContainsKey(exporter.ObjectPath)) // false = exporter was added but then manually removed
-                        current.Add(exporter);
-                }
-                if (current.Count == 0) break;
+                MaxDegreeOfParallelism = MaxDegreeOfParallelism,
+                CancellationToken = ct
+            };
+            var drained = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            if (TotalQueued == 0) drained.TrySetResult();
 
-                await Parallel.ForEachAsync(current, parallelOptions, Process).ConfigureAwait(false);
+            await Parallel.ForEachAsync(ReadAll(), parallelOptions, Process).ConfigureAwait(false);
+
+            async IAsyncEnumerable<ExporterBase> ReadAll([EnumeratorCancellation] CancellationToken token = default)
+            {
+                while (true)
+                {
+                    token.ThrowIfCancellationRequested();
+                    if (_queue.Reader.TryRead(out var entry))
+                    {
+                        if (entry.Take() is { } exporter)
+                            yield return exporter;
+                        continue;
+                    }
+
+                    if (TotalQueued == 0) yield break;
+
+                    var workAvailable = _queue.Reader.WaitToReadAsync(token).AsTask();
+                    if (await Task.WhenAny(workAvailable, drained.Task).ConfigureAwait(false) == drained.Task)
+                        yield break;
+
+                    if (!await workAvailable.ConfigureAwait(false)) yield break;
+                }
+            }
+
+            async ValueTask Process(ExporterBase exporter, CancellationToken token)
+            {
+                var result = await exporter.ExportAsync(token).ConfigureAwait(false);
+                results.Enqueue(result);
+
+                var stillQueued = Interlocked.Decrement(ref _totalQueued);
+                var count = results.Count;
+                OnPropertyChanged(nameof(TotalQueued));
+                OnPropertyChanged(nameof(HasQueuedItems));
+
+                progress?.Report(new ExportProgress(count, count + stillQueued, result));
+                if (stillQueued == 0) drained.TrySetResult();
             }
         }
         finally // just in case cancellation is requested, we still need to clear things up
@@ -140,20 +197,6 @@ public sealed class ExportSession(Action<StreamingLevelFilterArgs, CancellationT
         }
 
         return [.. results];
-
-        async ValueTask Process(IExporter exporter, CancellationToken token)
-        {
-            var result = await exporter.ExportAsync(token).ConfigureAwait(false);
-            results.Enqueue(result);
-
-            var stillQueued = Interlocked.Decrement(ref _totalQueued);
-            var count = results.Count;
-            OnPropertyChanged(nameof(TotalQueued));
-            OnPropertyChanged(nameof(HasQueuedItems));
-
-            progress?.Report(new ExportProgress(count, count + stillQueued, result));
-
-        }
     }
 
     internal string ResolveOutputPath(string savePath, string ext, string? nameSuffix = null)
@@ -166,4 +209,10 @@ public sealed class ExportSession(Action<StreamingLevelFilterArgs, CancellationT
 
     public event PropertyChangedEventHandler? PropertyChanged;
     private void OnPropertyChanged([CallerMemberName] string? name = null) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+
+    private sealed class QueueEntry(ExporterBase exporter)
+    {
+        private ExporterBase? _exporter = exporter;
+        public ExporterBase? Take() => Interlocked.Exchange(ref _exporter, null);
+    }
 }

--- a/CUE4Parse-Conversion/Exporters/DeferredObjectExporter.cs
+++ b/CUE4Parse-Conversion/Exporters/DeferredObjectExporter.cs
@@ -1,0 +1,72 @@
+using CUE4Parse.FileProvider;
+using CUE4Parse.FileProvider.Objects;
+using CUE4Parse.UE4.Assets.Exports;
+
+namespace CUE4Parse_Conversion.Exporters;
+
+/// <summary>
+/// Keeps enough information to recreate a built-in exporter without keeping its package alive.
+/// The original object is preferred while another owner still references it, avoiding a reload for
+/// short-lived sessions such as FModel's snooper export.
+/// </summary>
+internal sealed class DeferredObjectExporter : ExporterBase
+{
+    private readonly WeakReference<UObject> _export;
+    private readonly IFileProvider _provider;
+    private readonly GameFile _packageFile;
+    private readonly int _exportIndex;
+
+    private DeferredObjectExporter(UObject export, IFileProvider provider, GameFile packageFile, int exportIndex)
+        : base(export)
+    {
+        _export = new WeakReference<UObject>(export);
+        _provider = provider;
+        _packageFile = packageFile;
+        _exportIndex = exportIndex;
+    }
+
+    internal static DeferredObjectExporter? TryCreate(UObject export)
+    {
+        if (export.Owner is not { Provider: { } provider } owner ||
+            !provider.TryGetGameFile(owner.Name, out var packageFile))
+        {
+            return null;
+        }
+
+        for (var exportIndex = 0; exportIndex < owner.ExportsLazy.Length; exportIndex++)
+        {
+            var candidate = owner.ExportsLazy[exportIndex];
+            if (!candidate.IsValueCreated || !ReferenceEquals(candidate.Value, export)) continue;
+
+            return new DeferredObjectExporter(export, provider, packageFile, exportIndex);
+        }
+
+        return null;
+    }
+
+    public override async Task<ExportResult> ExportAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            if (!_export.TryGetTarget(out var export))
+            {
+                var package = await _provider.LoadPackageAsync(_packageFile).ConfigureAwait(false);
+                export = package.GetExport(_exportIndex) ??
+                         throw new InvalidOperationException($"Package '{package.Name}' no longer has export index {_exportIndex}.");
+                _export.SetTarget(export);
+            }
+
+            var exporter = ExportSession.CreateExporter(export);
+            exporter._session = _session;
+            return await exporter.ExportAsync(ct).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            Log.Error(ex, "Failed to load deferred export");
+            return ExportResult.Failure(ObjectPath, ex);
+        }
+    }
+
+    protected override IReadOnlyList<ExportFile> BuildExportFiles(CancellationToken ct = default) =>
+        throw new NotSupportedException();
+}

--- a/CUE4Parse-Conversion/Exporters/ExporterBase.cs
+++ b/CUE4Parse-Conversion/Exporters/ExporterBase.cs
@@ -45,7 +45,7 @@ public abstract class ExporterBase : IExporter
         ObjectPath = PackagePath + '.' + ObjectName;
         ClassName = className;
 
-        Log = Serilog.Log.ForContext(GetType())
+        Log = CUE4ParseLog.Log.ForContext(GetType())
             .ForContext(nameof(ObjectPath), ObjectPath)
             .ForContext(nameof(ClassName), ClassName)
             .ForContext("ExporterV2", true);
@@ -64,7 +64,7 @@ public abstract class ExporterBase : IExporter
 
     protected abstract IReadOnlyList<ExportFile> BuildExportFiles(CancellationToken ct = default);
 
-    public async Task<ExportResult> ExportAsync(CancellationToken ct = default)
+    public virtual async Task<ExportResult> ExportAsync(CancellationToken ct = default)
     {
         try
         {

--- a/CUE4Parse.Tests/ExportSessionTests.cs
+++ b/CUE4Parse.Tests/ExportSessionTests.cs
@@ -1,0 +1,195 @@
+using System.Runtime.CompilerServices;
+using CUE4Parse.Tests.Fixtures.UE5_8;
+using CUE4Parse.UE4.Assets.Exports;
+using CUE4Parse.UE4.Assets.Exports.Texture;
+using CUE4Parse_Conversion;
+using CUE4Parse_Conversion.Exporters;
+using CUE4Parse_Conversion.Options;
+using static CUE4Parse.Tests.Fixtures.UE5_8.FixtureTestUtilities;
+
+namespace CUE4Parse.Tests;
+
+public class ExportSessionTests
+{
+    private static CancellationToken Ct => TestContext.Current.CancellationToken;
+
+    [Fact]
+    public async Task RunAsync_ReleasesCompletedExportersWhileOtherWorkIsRunning()
+    {
+        const int fastCount = 16;
+        using var gate = new ManualResetEventSlim();
+        var session = new ExportSession { MaxDegreeOfParallelism = 2 };
+        session.Add(new TestExporter("Slow", gate: gate));
+        var references = QueueExporters(session, fastCount);
+        using var directory = new TempDirectory();
+        var completed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var progress = new InlineProgress(value =>
+        {
+            if (value.Completed == fastCount) completed.TrySetResult();
+        });
+        var run = Task.Run(() => session.RunAsync(directory.Path, new ExportOptions(), progress, Ct), Ct);
+        try
+        {
+            await completed.Task.WaitAsync(TimeSpan.FromSeconds(10), Ct);
+            await AssertEventually(() => references.Count(reference => reference.IsAlive) <= 1,
+                "Completed exporters remained strongly referenced.");
+        }
+        finally
+        {
+            gate.Set();
+            await run.WaitAsync(TimeSpan.FromSeconds(10), Ct);
+        }
+    }
+
+    [Fact]
+    public async Task RunAsync_ProcessesDependenciesAndDeduplicatesObjectPaths()
+    {
+        var session = new ExportSession { MaxDegreeOfParallelism = 2 };
+        session.Add(new TestExporter("Root", enqueue: current =>
+        {
+            current.Add(new TestExporter("Dependency"));
+            current.Add(new TestExporter("Dependency"));
+        }));
+
+        var results = await Run(session);
+        Assert.Equal(["Dependency.Dependency", "Root.Root"],
+            results.Select(result => result.ObjectPath).Order(StringComparer.Ordinal).ToArray());
+    }
+
+    [Fact]
+    public async Task Add_ProviderBackedObjectCanBeCollectedAndReloadedForExport()
+    {
+        using var provider = CreateMountedIoStoreProvider(FixtureSerialization.Tagged,
+            compression: FixtureCompression.Uncompressed);
+        var session = new ExportSession { MaxDegreeOfParallelism = 1 };
+        var texture = QueueTexture(session, provider);
+        await AssertEventually(() => !texture.IsAlive, "The queued texture remained strongly referenced.");
+        using var directory = new TempDirectory();
+        var result = Assert.Single(await session.RunAsync(directory.Path, new ExportOptions(), ct: Ct));
+        Assert.True(result.Success, result.Error?.ToString());
+        Assert.All(Assert.IsAssignableFrom<IReadOnlyList<string>>(result.DiskFilePaths),
+            path => Assert.True(File.Exists(path)));
+    }
+
+    [Fact]
+    public async Task Remove_ReleasesTheQueuedExporter()
+    {
+        var session = new ExportSession();
+        var (objectPath, exporter) = QueueRemovableExporter(session);
+        Assert.True(session.Remove(objectPath));
+        Assert.Equal(0, session.TotalQueued);
+        await AssertEventually(() => !exporter.IsAlive, "A removed exporter remained strongly referenced.");
+    }
+
+    [Fact]
+    public async Task RunAsync_CancellationStopsWorkersAndClearsTheSession()
+    {
+        using var gate = new ManualResetEventSlim();
+        using var started = new ManualResetEventSlim();
+        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(Ct);
+        var session = new ExportSession { MaxDegreeOfParallelism = 2 };
+        session.Add(new TestExporter("Blocked", gate: gate, started: started));
+        session.Add(new TestExporter("Pending"));
+        using var directory = new TempDirectory();
+        var run = Task.Run(() => session.RunAsync(directory.Path, new ExportOptions(), ct: cancellation.Token), Ct);
+        try
+        {
+            Assert.True(await Task.Run(() => started.Wait(TimeSpan.FromSeconds(10)), Ct));
+            await cancellation.CancelAsync();
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+                await run.WaitAsync(TimeSpan.FromSeconds(10), Ct));
+            Assert.False(session.IsRunning);
+            Assert.False(session.HasQueuedItems);
+        }
+        finally
+        {
+            gate.Set();
+        }
+    }
+
+    [Fact]
+    public async Task RunAsync_SessionCanBeReusedAfterCompletion()
+    {
+        var session = new ExportSession { MaxDegreeOfParallelism = 1 };
+        using var directory = new TempDirectory();
+        session.Add(new TestExporter("First"));
+        var first = Assert.Single(await session.RunAsync(directory.Path, new ExportOptions(), ct: Ct));
+        session.Add(new TestExporter("Second"));
+        var second = Assert.Single(await session.RunAsync(directory.Path, new ExportOptions(), ct: Ct));
+        Assert.Equal(("First.First", "Second.Second"), (first.ObjectPath, second.ObjectPath));
+    }
+
+    private static async Task<IReadOnlyList<ExportResult>> Run(ExportSession session)
+    {
+        using var directory = new TempDirectory();
+        return await session.RunAsync(directory.Path, new ExportOptions(), ct: Ct);
+    }
+
+    private static async Task AssertEventually(Func<bool> condition, string message)
+    {
+        for (var attempt = 0; attempt < 40 && !condition(); attempt++)
+        {
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+            await Task.Delay(25, Ct);
+        }
+        Assert.True(condition(), message);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static List<WeakReference> QueueExporters(ExportSession session, int count)
+    {
+        var references = new List<WeakReference>(count);
+        for (var i = 0; i < count; i++)
+        {
+            var exporter = new TestExporter($"Fast{i}", new byte[128 * 1024]);
+            references.Add(new WeakReference(exporter));
+            session.Add(exporter);
+        }
+        return references;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static WeakReference QueueTexture(ExportSession session, CUE4Parse.FileProvider.DefaultFileProvider provider)
+    {
+        var texture = LoadExport<UTexture2D>(provider,
+            "CUE4ParseFixtures/Content/Fixtures/Textures/T_BGRA8.uasset", "T_BGRA8");
+        session.Add(texture);
+        return new WeakReference(texture);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static (string, WeakReference) QueueRemovableExporter(ExportSession session)
+    {
+        var exporter = new TestExporter("Removable", new byte[128 * 1024]);
+        session.Add(exporter);
+        return (exporter.ObjectPath, new WeakReference(exporter));
+    }
+
+    private sealed class InlineProgress(Action<ExportProgress> report) : IProgress<ExportProgress>
+    {
+        public void Report(ExportProgress value) => report(value);
+    }
+
+    private sealed class TempDirectory : IDisposable
+    {
+        public string Path { get; } = System.IO.Path.Combine(System.IO.Path.GetTempPath(),
+            "CUE4Parse.Tests", Guid.NewGuid().ToString("N"));
+        public TempDirectory() => Directory.CreateDirectory(Path);
+        public void Dispose() => Directory.Delete(Path, true);
+    }
+
+    private sealed class TestExporter(string name, byte[]? payload = null, ManualResetEventSlim? gate = null,
+        ManualResetEventSlim? started = null, Action<ExportSession>? enqueue = null) : ExporterBase(new UObject { Name = name })
+    {
+        protected override IReadOnlyList<ExportFile> BuildExportFiles(CancellationToken ct = default)
+        {
+            started?.Set();
+            gate?.Wait(ct);
+            enqueue?.Invoke(Session);
+            GC.KeepAlive(payload);
+            return [new ExportFile("bin", [1])];
+        }
+    }
+}


### PR DESCRIPTION
Fixes #413

- Stream exporters through Parallel.ForEachAsync and release queue references as work starts.
- Hold provider-backed UObjects weakly and reload their package/export index if collected.
- Preserve deduplication, dynamic dependencies, cancellation, custom exporters, and FModel logging.