### PR TITLE
strip leading ../ from stored file paths

### DIFF
--- a/CUE4Parse/UE4/IO/IoStoreReader.cs
+++ b/CUE4Parse/UE4/IO/IoStoreReader.cs
@@ -535,8 +535,7 @@ public partial class IoStoreReader : AbstractAesVfsReader
                 var fileEntry = fileEntries[file];
                 var name = stringTable[fileEntry.Name];
                 var fullPathLength = Write(pathBuffer, directoryLength, name, true);
-                var fullPathSpan = pathBuffer.AsSpan(..fullPathLength);
-                if (Game == GAME_NeedForSpeedMobile) fullPathSpan = fullPathSpan.SubstringAfter("../../../");
+                var fullPathSpan = NormalizeVirtualPath(pathBuffer.AsSpan(..fullPathLength));
                 var path = new string(fullPathSpan);
 
                 var entry = new FIoStoreEntry(this, path, fileEntry.UserData);

--- a/CUE4Parse/UE4/Pak/PakFileReader.cs
+++ b/CUE4Parse/UE4/Pak/PakFileReader.cs
@@ -342,7 +342,7 @@ public partial class PakFileReader : AbstractAesVfsReader
         var files = new Dictionary<string, GameFile>(fileCount, pathComparer);
         for (var i = 0; i < fileCount; i++)
         {
-            var path = string.Concat(mountPoint, index.ReadFString());
+            var path = NormalizeVirtualPath(string.Concat(mountPoint, index.ReadFString()));
             var entry = new FPakEntry(this, path, index);
             if (entry is { IsDeleted: true, Size: 0 }) continue;
             if (entry.IsEncrypted) EncryptedFileCount++;
@@ -464,7 +464,7 @@ public partial class PakFileReader : AbstractAesVfsReader
                 var fileName = directoryIndex.ReadFStringMemory(); // supports PakFile_Version_Utf8PakDirectory too
                 var fileNameLength = fileName.GetEncoding().GetChars(fileName.GetSpan(), fileNameSpan);
                 fileNameSpan = fileNameSpan[..fileNameLength];
-                var path = string.Concat(mountPointSpan, dirSpan, fileNameSpan);
+                var path = NormalizeVirtualPath(string.Concat(mountPointSpan, dirSpan, fileNameSpan));
 
                 var offset = directoryIndex.Read<int>();
                 if (offset == int.MinValue) continue;
@@ -558,7 +558,7 @@ public partial class PakFileReader : AbstractAesVfsReader
 
                 var nameStart = fileNameOffsets[global];
                 var fileName = Encoding.UTF8.GetString(fileBlob.AsSpan(nameStart, fileNameOffsets[global + 1] - nameStart));
-                var path = string.Concat(MountPoint, dir, fileName);
+                var path = NormalizeVirtualPath(string.Concat(MountPoint, dir, fileName));
 
                 FPakEntry entry;
                 if (location >= 0)
@@ -617,6 +617,7 @@ public partial class PakFileReader : AbstractAesVfsReader
                 else
                     path = string.Concat(mountPoint, dir, name);
 
+                path = NormalizeVirtualPath(path);
                 var entry = entries[fileIndex];
                 entry.Path = path;
 

--- a/CUE4Parse/UE4/VirtualFileSystem/AbstractVfsReader.cs
+++ b/CUE4Parse/UE4/VirtualFileSystem/AbstractVfsReader.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Runtime.CompilerServices;
 using CUE4Parse.FileProvider.Objects;
 using CUE4Parse.UE4.Assets.Objects;
@@ -65,6 +66,27 @@ namespace CUE4Parse.UE4.VirtualFileSystem
 
             mountPoint = mountPoint[1..];
             VerifyReadOrder();
+        }
+
+        public static string NormalizeVirtualPath(string path)
+        {
+            var i = SkipLeadingParents(path.AsSpan());
+            return i == 0 ? path : path[i..];
+        }
+
+        public static ReadOnlySpan<char> NormalizeVirtualPath(ReadOnlySpan<char> path)
+        {
+            var i = SkipLeadingParents(path);
+            return i == 0 ? path : path[i..];
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int SkipLeadingParents(ReadOnlySpan<char> path)
+        {
+            var i = 0;
+            while (i + 3 <= path.Length && path[i] == '.' && path[i + 1] == '.' && path[i + 2] == '/')
+                i += 3;
+            return i;
         }
 
         private void VerifyReadOrder()


### PR DESCRIPTION
Fix path extension for
```
../../../FortniteGame/Content/ShaderArchive-FortniteGame_Chunk0-PCD3D_ES31-PCD3D_ES3_1.ushaderbytecode
../../../FortniteGame/Content/ShaderArchive-FortniteGame_Chunk0-PCD3D_SM6-PCD3D_SM6.ushaderbytecode
../../../FortniteGame/Content/ShaderArchive-Global-PCD3D_ES31-PCD3D_ES3_1.ushaderbytecode
../../../FortniteGame/Content/ShaderArchive-Global-PCD3D_SM5-PCD3D_SM5.ushaderbytecode
../../../FortniteGame/Content/ShaderArchive-Global-PCD3D_SM6-PCD3D_SM6.ushaderbytecode
```
 
This has already been solved in another PR