### PR TITLE
Fix Wuthering Waves (3.6+) virtual texture chunk parsing skip bulkDataHash

### DIFF
--- a/CUE4Parse/UE4/Assets/Exports/Texture/FVirtualTextureDataChunk.cs
+++ b/CUE4Parse/UE4/Assets/Exports/Texture/FVirtualTextureDataChunk.cs
@@ -31,7 +31,7 @@ namespace CUE4Parse.UE4.Assets.Exports.Texture
         {
             CodecType = new EVirtualTextureCodec[numLayers];
             CodecPayloadOffset = new uint[numLayers];
-            if (Ar.Game >= GAME_UE5_0)
+            if (Ar.Game >= GAME_UE5_0 || Ar.Game == GAME_WutheringWaves) // WuWa (3.6+) also serializes a bulkDataHash in the VT chunk, same as UE5
                 Ar.Position += FSHAHash.SIZE; // var bulkDataHash = new FSHAHash(Ar);
 
             SizeInBytes = Ar.Read<uint>();

--- a/CUE4Parse/UE4/Assets/Exports/Texture/FVirtualTextureDataChunk.cs
+++ b/CUE4Parse/UE4/Assets/Exports/Texture/FVirtualTextureDataChunk.cs
@@ -31,7 +31,7 @@ namespace CUE4Parse.UE4.Assets.Exports.Texture
         {
             CodecType = new EVirtualTextureCodec[numLayers];
             CodecPayloadOffset = new uint[numLayers];
-            if (Ar.Game >= GAME_UE5_0 || Ar.Game == GAME_WutheringWaves) // WuWa (3.6+) also serializes a bulkDataHash in the VT chunk, same as UE5
+            if (Ar.Game >= GAME_UE5_0 || Ar.Game == GAME_WutheringWaves)
                 Ar.Position += FSHAHash.SIZE; // var bulkDataHash = new FSHAHash(Ar);
 
             SizeInBytes = Ar.Read<uint>();


### PR DESCRIPTION
Wuthering Waves 3.6+ serializes a 20-byte bulkDataHash (FSHAHash) for every
virtual texture data chunk, same as UE5. The existing FVirtualTextureDataChunk
only skips it when `Ar.Game >= GAME_UE5_0`. Wuthering Waves is built on UE4.26
(enum value < UE5_0), so the hash was NOT skipped, and the first 4 bytes of the
hash were misread as SizeInBytes. This shifted the whole chunk table, made the
chunk's FByteBulkData empty, and DecodeVT hit "Source array was not long enough"
(Array.Copy) when copying a tile -> Snooper preview of meshes using these VTs
(e.g. SM_Gel_Box_21AM) crashed on double-click.

Change:
- FVirtualTextureDataChunk.cs: also skip FSHAHash.SIZE for GAME_WutheringWaves.

Verified:
- T2_Mez_Met_02A_D/_M/_N (VT): chunk data fully read after the fix.
  D: 185659 + 65507 = 251166 = exact .ubulk file size; M/N also match. All three
  decode OK, no Array.Copy.
- T2_Mez_Met_03A (non-VT): unaffected, decodes normally.
- SM_Gel_Box_21AM material textures now decode and Snooper preview loads.