### PR TITLE
Optimised TryGet methods in File Providers

### DIFF
--- a/CUE4Parse/FileProvider/AbstractFileProvider.cs
+++ b/CUE4Parse/FileProvider/AbstractFileProvider.cs
@@ -186,16 +186,8 @@ namespace CUE4Parse.FileProvider
                 : throw new KeyNotFoundException($"There is no game file with the path \"{path}\"");
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool TryGetGameFile(string path, [MaybeNullWhen(false)] out GameFile file)
-        {
-            file = null;
-            try
-            {
-                return TryGetGameFile(path, Files, out file);
-            }
-            catch { }
-            return false;
-        }
+        public bool TryGetGameFile(string path, [MaybeNullWhen(false)] out GameFile file) => 
+            TryGetGameFile(path, Files, out file);
 
         public int LoadLocalization(ELanguage language = ELanguage.English, CancellationToken cancellationToken = default)
             => LoadLocalization(GetLanguageCode(language), cancellationToken);

--- a/CUE4Parse/FileProvider/AbstractFileProvider.cs
+++ b/CUE4Parse/FileProvider/AbstractFileProvider.cs
@@ -188,15 +188,13 @@ namespace CUE4Parse.FileProvider
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool TryGetGameFile(string path, [MaybeNullWhen(false)] out GameFile file)
         {
+            file = null;
             try
             {
-                file = this[path];
+                return TryGetGameFile(path, Files, out file);
             }
-            catch
-            {
-                file = null;
-            }
-            return file != null;
+            catch { }
+            return false;
         }
 
         public int LoadLocalization(ELanguage language = ELanguage.English, CancellationToken cancellationToken = default)

--- a/CUE4Parse/FileProvider/Vfs/AbstractVfsFileProvider.cs
+++ b/CUE4Parse/FileProvider/Vfs/AbstractVfsFileProvider.cs
@@ -49,7 +49,7 @@ namespace CUE4Parse.FileProvider.Vfs
 {
     public abstract class AbstractVfsFileProvider : AbstractFileProvider, IVfsFileProvider
     {
-        
+
         protected readonly ConcurrentDictionary<IAesVfsReader, object?> _unloadedVfs = new ();
         public IReadOnlyCollection<IAesVfsReader> UnloadedVfs => (IReadOnlyCollection<IAesVfsReader>) _unloadedVfs.Keys;
 
@@ -412,17 +412,14 @@ namespace CUE4Parse.FileProvider.Vfs
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public IAesVfsReader GetArchive(string archiveName, StringComparison comparison = StringComparison.Ordinal)
-            => GetArchiveOrNull(archiveName, comparison) is IAesVfsReader archive
-            ? archive
-            : throw new KeyNotFoundException($"There is no archive file with the name \"{archiveName}\"");
+            => GetArchiveOrNull(archiveName, comparison) ?? throw new KeyNotFoundException($"There is no archive file with the name \"{archiveName}\"");
 
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public IAesVfsReader? GetArchiveOrNull(string archiveName, StringComparison comparison = StringComparison.Ordinal)
         {
+            return MountedVfs.FirstOrDefault(Predicate) ?? UnloadedVfs.FirstOrDefault(Predicate);
             bool Predicate(IAesVfsReader x) => x.Name.Equals(archiveName, comparison);
-            return MountedVfs.FirstOrDefault(Predicate) ??
-                   UnloadedVfs.FirstOrDefault(Predicate);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -442,9 +439,7 @@ namespace CUE4Parse.FileProvider.Vfs
         public bool TryGetGameFile(string path, string archiveName, [MaybeNullWhen(false)] out GameFile file, StringComparison comparison = StringComparison.Ordinal)
         {
             file = null;
-            if (!TryGetArchive(archiveName, out var archive, comparison))
-                return false;
-            return TryGetGameFile(path, archive.Files, out file);
+            return TryGetArchive(archiveName, out var archive, comparison) && TryGetGameFile(path, archive.Files, out file);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/CUE4Parse/FileProvider/Vfs/AbstractVfsFileProvider.cs
+++ b/CUE4Parse/FileProvider/Vfs/AbstractVfsFileProvider.cs
@@ -412,18 +412,17 @@ namespace CUE4Parse.FileProvider.Vfs
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public IAesVfsReader GetArchive(string archiveName, StringComparison comparison = StringComparison.Ordinal)
-            => TryGetArchiveUnsafe(archiveName, out var archive, comparison)
+            => GetArchiveOrNull(archiveName, comparison) is IAesVfsReader archive
             ? archive
             : throw new KeyNotFoundException($"There is no archive file with the name \"{archiveName}\"");
 
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        protected bool TryGetArchiveUnsafe(string archiveName, [MaybeNullWhen(false)] out IAesVfsReader archive, StringComparison comparison = StringComparison.Ordinal)
+        public IAesVfsReader? GetArchiveOrNull(string archiveName, StringComparison comparison = StringComparison.Ordinal)
         {
-            var predicate = (IAesVfsReader x) => x.Name.Equals(archiveName, comparison);
-            archive = MountedVfs.FirstOrDefault(predicate) ??
-                   UnloadedVfs.FirstOrDefault(predicate);
-            return archive != null;
+            bool Predicate(IAesVfsReader x) => x.Name.Equals(archiveName, comparison);
+            return MountedVfs.FirstOrDefault(Predicate) ??
+                   UnloadedVfs.FirstOrDefault(Predicate);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -432,10 +431,10 @@ namespace CUE4Parse.FileProvider.Vfs
             archive = null;
             try
             {
-                return TryGetArchiveUnsafe(archiveName, out archive, comparison);
+                archive = GetArchiveOrNull(archiveName, comparison);
             }
             catch { }
-            return false;
+            return archive is not null;
         }
 
         public GameFile this[string path, string archiveName, StringComparison comparison = StringComparison.Ordinal] => this[path, GetArchive(archiveName, comparison)];

--- a/CUE4Parse/FileProvider/Vfs/AbstractVfsFileProvider.cs
+++ b/CUE4Parse/FileProvider/Vfs/AbstractVfsFileProvider.cs
@@ -428,12 +428,7 @@ namespace CUE4Parse.FileProvider.Vfs
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool TryGetArchive(string archiveName, [MaybeNullWhen(false)] out IAesVfsReader archive, StringComparison comparison = StringComparison.Ordinal)
         {
-            archive = null;
-            try
-            {
-                archive = GetArchiveOrNull(archiveName, comparison);
-            }
-            catch { }
+            archive = GetArchiveOrNull(archiveName, comparison);
             return archive is not null;
         }
 
@@ -447,14 +442,9 @@ namespace CUE4Parse.FileProvider.Vfs
         public bool TryGetGameFile(string path, string archiveName, [MaybeNullWhen(false)] out GameFile file, StringComparison comparison = StringComparison.Ordinal)
         {
             file = null;
-            try
-            {
-                if (!TryGetArchive(archiveName, out var archive, comparison))
-                    return false;
-                return TryGetGameFile(path, archive.Files, out file);
-            }
-            catch { }
-            return false;
+            if (!TryGetArchive(archiveName, out var archive, comparison))
+                return false;
+            return TryGetGameFile(path, archive.Files, out file);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/CUE4Parse/FileProvider/Vfs/AbstractVfsFileProvider.cs
+++ b/CUE4Parse/FileProvider/Vfs/AbstractVfsFileProvider.cs
@@ -412,25 +412,30 @@ namespace CUE4Parse.FileProvider.Vfs
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public IAesVfsReader GetArchive(string archiveName, StringComparison comparison = StringComparison.Ordinal)
+            => TryGetArchiveUnsafe(archiveName, out var archive, comparison)
+            ? archive
+            : throw new KeyNotFoundException($"There is no archive file with the name \"{archiveName}\"");
+
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected bool TryGetArchiveUnsafe(string archiveName, [MaybeNullWhen(false)] out IAesVfsReader archive, StringComparison comparison = StringComparison.Ordinal)
         {
             var predicate = (IAesVfsReader x) => x.Name.Equals(archiveName, comparison);
-            return MountedVfs.FirstOrDefault(predicate) ??
-                   UnloadedVfs.FirstOrDefault(predicate) ??
-                   throw new KeyNotFoundException($"There is no archive file with the name \"{archiveName}\"");
+            archive = MountedVfs.FirstOrDefault(predicate) ??
+                   UnloadedVfs.FirstOrDefault(predicate);
+            return archive != null;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool TryGetArchive(string archiveName, [MaybeNullWhen(false)] out IAesVfsReader archive, StringComparison comparison = StringComparison.Ordinal)
         {
+            archive = null;
             try
             {
-                archive = GetArchive(archiveName, comparison);
+                return TryGetArchiveUnsafe(archiveName, out archive, comparison);
             }
-            catch
-            {
-                archive = null;
-            }
-            return archive != null;
+            catch { }
+            return false;
         }
 
         public GameFile this[string path, string archiveName, StringComparison comparison = StringComparison.Ordinal] => this[path, GetArchive(archiveName, comparison)];
@@ -442,15 +447,15 @@ namespace CUE4Parse.FileProvider.Vfs
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool TryGetGameFile(string path, string archiveName, [MaybeNullWhen(false)] out GameFile file, StringComparison comparison = StringComparison.Ordinal)
         {
+            file = null;
             try
             {
-                file = this[path, archiveName, comparison];
+                if (!TryGetArchive(archiveName, out var archive, comparison))
+                    return false;
+                return TryGetGameFile(path, archive.Files, out file);
             }
-            catch
-            {
-                file = null;
-            }
-            return file != null;
+            catch { }
+            return false;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
Multiple TryGet methods in AbstractFileProvider and AbstractVfsFileProvider were needlessly throwing and catching exceptions to implement their TryGet behaviour, which significantly slowed down applications trying to get files that didn't exist